### PR TITLE
Fix monitor heartbeat table

### DIFF
--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -170,6 +170,13 @@ class DataLocker:
                     source TEXT
                 )
             """,
+            "monitor_heartbeat": """
+                CREATE TABLE IF NOT EXISTS monitor_heartbeat (
+                    monitor_name TEXT PRIMARY KEY,
+                    last_run TIMESTAMP NOT NULL,
+                    interval_seconds INTEGER NOT NULL
+                )
+            """,
             "system_vars": """
             CREATE TABLE IF NOT EXISTS system_vars (
     id TEXT PRIMARY KEY DEFAULT 'main',


### PR DESCRIPTION
## Summary
- create the `monitor_heartbeat` table when DataLocker initializes

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*