### PR TITLE
Add size composition pie chart to Sonic dashboard

### DIFF
--- a/static/js/size_pie.js
+++ b/static/js/size_pie.js
@@ -1,0 +1,20 @@
+// size_pie.js - render LONG vs SHORT size composition pie chart
+window.addEventListener('DOMContentLoaded', () => {
+  const data = window.sizeData?.series || [];
+  const isZero = data.every(v => v === 0);
+  const options = {
+    chart: { type: 'donut', height: 260 },
+    labels: ['Long', 'Short'],
+    series: isZero ? [1] : data,
+    colors: isZero ? ['#ccc'] : ['#3498db', '#e74c3c'],
+    legend: { position: 'bottom' },
+    title: {
+      text: 'Size Composition',
+      align: 'center',
+      style: { fontSize: '14px', fontWeight: 'bold' }
+    },
+    tooltip: { y: { formatter: val => `${val}%` } }
+  };
+  const chart = new ApexCharts(document.querySelector('#pieChartSize'), options);
+  chart.render();
+});

--- a/templates/dash_bottom.html
+++ b/templates/dash_bottom.html
@@ -1,5 +1,7 @@
 <div class="sonic-section-container sonic-section-bottom">
   <div class="section-title">Bottom Section</div>
   <div class="sonic-content-panel">Bottom Left</div>
-  <div class="sonic-content-panel">Bottom Right</div>
+  <div class="sonic-content-panel">
+    <div id="pieChartSize">Loading...</div>
+  </div>
 </div>

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -117,4 +117,9 @@
     });
   </script>
   <script src="{{ url_for('static', filename='js/dashboard_top.js') }}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+  <script>
+    const sizeData = {{ size_composition | tojson }};
+  </script>
+  <script src="{{ url_for('static', filename='js/size_pie.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show a new ApexCharts pie chart of long vs short size
- load chart data from `size_composition` in the context
- include ApexCharts library and new JS file

## Testing
- `pytest -q` *(fails: pytest not installed)*