### PR TITLE
Add toggleable size composition chart

### DIFF
--- a/static/js/size_pie.js
+++ b/static/js/size_pie.js
@@ -1,0 +1,33 @@
+// size_pie.js - render LONG vs SHORT size composition pie chart
+window.addEventListener('DOMContentLoaded', () => {
+  const data = window.sizeData?.series || [];
+  const isZero = data.every(v => v === 0);
+  const options = {
+    chart: { type: 'donut', height: 260 },
+    labels: ['Long', 'Short'],
+    series: isZero ? [1] : data,
+    colors: isZero ? ['#ccc'] : ['#3498db', '#e74c3c'],
+    legend: { position: 'bottom' },
+    title: {
+      text: 'Size Composition',
+      align: 'center',
+      style: { fontSize: '14px', fontWeight: 'bold' }
+    },
+    tooltip: { y: { formatter: val => `${val}%` } }
+  };
+  const chartEl = document.querySelector('#pieChartSize');
+  const chart = new ApexCharts(chartEl, options);
+  chart.render();
+
+  // allow toggling donut vs pie
+  const btn = document.getElementById('togglePieType');
+  let donut = true;
+  if (btn) {
+    btn.addEventListener('click', () => {
+      donut = !donut;
+      chart.updateOptions({ chart: { type: donut ? 'donut' : 'pie' } });
+      btn.textContent = donut ? 'Full Pie' : 'Donut';
+    });
+  }
+});
+

--- a/templates/dash_bottom.html
+++ b/templates/dash_bottom.html
@@ -1,5 +1,8 @@
 <div class="sonic-section-container sonic-section-bottom">
   <div class="section-title">Bottom Section</div>
   <div class="sonic-content-panel">Bottom Left</div>
-  <div class="sonic-content-panel">Bottom Right</div>
+  <div class="sonic-content-panel">
+    <div id="pieChartSize">Loading...</div>
+    <button id="togglePieType" class="btn btn-sm btn-secondary mt-2">Full Pie</button>
+  </div>
 </div>

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -117,4 +117,9 @@
     });
   </script>
   <script src="{{ url_for('static', filename='js/dashboard_top.js') }}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+  <script>
+    window.sizeData = {{ size_composition | tojson }};
+  </script>
+  <script src="{{ url_for('static', filename='js/size_pie.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- wire sizeData as global for chart script
- add a button to toggle donut vs full pie chart
- render donut chart with click handler

## Testing
- `pytest -q` *(fails: pytest not installed)*