### PR TITLE
Add size composition pie chart toggle

### DIFF
--- a/static/js/size_pie.js
+++ b/static/js/size_pie.js
@@ -1,0 +1,31 @@
+// size_pie.js - render LONG vs SHORT size composition pie chart
+window.addEventListener('DOMContentLoaded', () => {
+  const data = window.sizeData?.series || [];
+  const isZero = data.every(v => v === 0);
+  const base = {
+    labels: ['Long', 'Short'],
+    series: isZero ? [1] : data,
+    colors: isZero ? ['#ccc'] : ['#3498db', '#e74c3c'],
+    legend: { position: 'bottom' },
+    title: {
+      text: 'Size Composition',
+      align: 'center',
+      style: { fontSize: '14px', fontWeight: 'bold' }
+    },
+    tooltip: { y: { formatter: val => `${val}%` } }
+  };
+
+  let mode = 'donut';
+  const chartEl = document.querySelector('#pieChartSize');
+  const chart = new ApexCharts(chartEl, { ...base, chart: { type: mode, height: 260 } });
+  chart.render();
+
+  const btn = document.getElementById('togglePieMode');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      mode = mode === 'donut' ? 'pie' : 'donut';
+      chart.updateOptions({ chart: { type: mode } });
+    });
+  }
+});
+

--- a/templates/dash_bottom.html
+++ b/templates/dash_bottom.html
@@ -1,5 +1,9 @@
 <div class="sonic-section-container sonic-section-bottom">
   <div class="section-title">Bottom Section</div>
   <div class="sonic-content-panel">Bottom Left</div>
-  <div class="sonic-content-panel">Bottom Right</div>
+  <div class="sonic-content-panel">
+    <div id="pieChartSize" class="mb-2">Loading...</div>
+    <button id="togglePieMode" class="btn btn-outline-secondary btn-sm">Toggle Chart Type</button>
+  </div>
 </div>
+

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -117,4 +117,9 @@
     });
   </script>
   <script src="{{ url_for('static', filename='js/dashboard_top.js') }}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+  <script>
+    const sizeData = {{ size_composition | tojson }};
+  </script>
+  <script src="{{ url_for('static', filename='js/size_pie.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add toggle button below size composition chart
- enable switching between donut and pie modes in `size_pie.js`

## Testing
- `pytest -q` *(fails: command not found)*