### PR TITLE
Remove redundant containers from dashboard

### DIFF
--- a/templates/monitor_cards.html
+++ b/templates/monitor_cards.html
@@ -1,6 +1,5 @@
-<div class="dashboard-section">
-  <div class="section-title">Monitor</div>
-  <div class="card-flex">
+<div class="section-title">Monitor</div>
+<div class="card-flex">
     {% for item in monitor_items %}
       <div class="flip-card">
         <div class="flip-card-inner">
@@ -44,5 +43,4 @@
         </div>
       </div>
     {% endfor %}
-  </div>
 </div>

--- a/templates/portfolio_cards.html
+++ b/templates/portfolio_cards.html
@@ -1,6 +1,5 @@
-<div class="dashboard-section">
-  <div class="section-title">Portfolio</div>
-  <div class="card-flex">
+<div class="section-title">Portfolio</div>
+<div class="card-flex">
     {% for item in status_items %}
       <div class="flip-card">
         <div class="flip-card-inner">
@@ -20,5 +19,4 @@
         </div>
       </div>
     {% endfor %}
-  </div>
 </div>


### PR DESCRIPTION
## Summary
- clean up markup in dash_top by removing `dashboard-section` wrappers

## Testing
- `pytest -q` *(fails: command not found)*