### PR TITLE
Implement DB viewer data loading

### DIFF
--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -300,3 +300,14 @@ class DataLocker:
         self.db.commit()
         log.success("✅ Seeded default thresholds", source="DataLocker")
 
+    def get_all_tables_as_dict(self) -> dict:
+        """Return all user tables and their rows as a dictionary."""
+        try:
+            datasets = {}
+            for table in self.db.list_tables():
+                datasets[table] = self.db.fetch_all(table)
+            return datasets
+        except Exception as e:
+            log.error(f"❌ Failed to gather tables: {e}", source="DataLocker")
+            return {}
+

--- a/data/database.py
+++ b/data/database.py
@@ -29,3 +29,19 @@ class DatabaseManager:
         if self.conn:
             self.conn.close()
             self.conn = None
+
+    # New helper methods
+    def list_tables(self) -> list:
+        """Return a list of user-defined table names."""
+        cursor = self.get_cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+    def fetch_all(self, table_name: str) -> list:
+        """Return all rows from a table as a list of dictionaries."""
+        cursor = self.get_cursor()
+        cursor.execute(f"SELECT * FROM {table_name}")
+        rows = cursor.fetchall()
+        return [dict(r) for r in rows]

--- a/templates/db_viewer.html
+++ b/templates/db_viewer.html
@@ -9,6 +9,7 @@
 {% endblock %}
 
 {% block content %}
+{% include "title_bar.html" %}
 <div class="container py-4">
   <h2 class="mb-3">Database Viewer</h2>
   <div class="mb-3">


### PR DESCRIPTION
## Summary
- extend base db viewer page with title bar
- add DB helpers for listing tables and fetching them
- expose get_all_tables_as_dict in DataLocker

## Testing
- `pytest -q` *(fails: pytest not installed)*