### PR TITLE
Add hedge calculator template and system route

### DIFF
--- a/templates/hedge_calculator.html
+++ b/templates/hedge_calculator.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block title %}Hedge Calculator{% endblock %}
+{% block page_title %}{% endblock %}
+
+{% block content %}
+<h1>Hedge Calculator</h1>
+<p>TODO: full hedge calculator content.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add hedge_calculator.html template placeholder
- expose `/system/hedge_calculator` route

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*