### PR TITLE
Restore dashboard liquidation bars

### DIFF
--- a/static/css/dashboard_middle.css
+++ b/static/css/dashboard_middle.css
@@ -1,0 +1,67 @@
+/* ===== Dashboard Middle Layout (Side by Side, Bulletproof) ===== */
+
+/* Parent flex row for the two containers */
+.dashboard-middle-flex {
+  display: flex;
+  flex-direction: row;
+  gap: 2.2rem;
+  width: 100%;
+  align-items: stretch;
+  justify-content: center;
+  overflow-x: auto;        /* Allow horizontal scroll if squeezed too much */
+  min-width: 0;            /* Fix for flex children overflow */
+}
+
+/* Each half of the middle row */
+.dashboard-middle-half {
+  flex: 1 1 320px;         /* Allow to grow and shrink, with sensible minimum */
+  min-width: 240px;        /* Lower min-width lets it fit on smaller screens */
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 1px;
+  min-width: 0;            /* CRITICAL: prevents flex overflow clipping */
+}
+
+/* The card container */
+.dashboard-section {
+  flex: 1 1 auto;
+  min-width: 0;            /* CRITICAL for child table/grid overflow! */
+  min-height: 1px;
+  background: var(--card-bg, #fff);
+  border-radius: 14px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  padding: 1.2rem 1.3rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  margin-bottom: 0;
+  overflow: visible;
+}
+
+/* Section titles inside the cards */
+.section-title {
+  font-size: 1.13rem;
+  font-weight: bold;
+  margin-bottom: 1.1rem;
+  color: var(--text, #222);
+  letter-spacing: 0.04em;
+}
+
+/* Responsive: Stack vertically on tablet/mobile */
+@media (max-width: 950px) {
+  .dashboard-middle-flex {
+    flex-direction: column;
+    gap: 1.3rem;
+    min-width: 0;
+  }
+  .dashboard-middle-half {
+    min-width: 0;
+    width: 100%;
+    border-radius: 9px;
+  }
+  .dashboard-section {
+    padding: 0.7rem 0.6rem;
+    border-radius: 9px;
+  }
+}

--- a/static/css/liquidation_bars.css
+++ b/static/css/liquidation_bars.css
@@ -1,0 +1,134 @@
+/* =======================
+   LIQUIDATION.CSS — Bars, Badges, Midlines, Profit/Heat
+   ======================= */
+
+/* === 💥 Liquidation Container Layout === */
+.liq-col {
+  display: flex;
+  flex: 2;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+/* === 🔘 Gray Background Bar === */
+.liq-bar-container {
+  position: relative;
+  flex-grow: 1;
+  height: 20px;
+  background: #e0e0e0;
+  border-radius: 999px;         /* 💎 Full pill shape */
+  overflow: hidden;
+}
+
+/* === 🪵 Midline Divider (Center) === */
+.liq-midline {
+  position: absolute;
+  left: 50%;
+  width: 2px;
+  height: 100%;
+  background: #333;
+  z-index: 2;
+}
+
+/* === 🚀 Bar Fill (Positive = Right, Negative = Left) === */
+.liq-bar-fill {
+  position: absolute;
+  height: 100%;
+  top: 0;
+  padding: 0 4px;
+  min-width: 3.5rem;            /* 🔧 Always enough for text */
+  border-radius: 999px;
+  font-size: 0.8rem;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.4s ease;
+}
+
+/* 📈 Green Travel Right */
+.liq-bar-fill.positive {
+  left: 50%;
+  background: repeating-linear-gradient(
+    45deg, #28a745, #28a745 10px,
+    #2ecc71 10px, #2ecc71 20px
+  );
+}
+
+/* 📉 Red Travel Left */
+.liq-bar-fill.negative {
+  right: 50%;
+  background: repeating-linear-gradient(
+    45deg, #dc3545, #dc3545 10px,
+    #e74c3c 10px, #e74c3c 20px
+  );
+}
+
+/* 🏷️ Travel % Label */
+.travel-text {
+  z-index: 10;
+  white-space: nowrap;
+}
+
+/* === 🔥 Heat Index Badge (Right Side) === */
+.liq-heat-badge {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: #ff5722;
+  color: #fff;
+  font-weight: bold;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* === 💰 Profit Badge (Left Side) === */
+.liq-profit-badge-wrapper {
+  position: absolute;
+  left: -14px;                       /* 🔧 Push badge snug to bar */
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.liq-profit-badge {
+  background-color: #00b050;
+  color: white;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 13px;
+  box-shadow: 0 0 3px rgba(0,0,0,0.4);
+  margin-top: 2px;
+}
+
+/* === 🔥 Flame & 💵 Profit Icons Above Badges === */
+.heat-label-wrapper,
+.profit-label-wrapper {
+  position: relative;
+  flex: 0 0 30px;
+  height: 100%;
+}
+
+.heat-icon,
+.profit-icon {
+  width: 20px;
+  height: 20px;
+  animation: bounceFlame 1.4s infinite ease-in-out;
+}
+
+@keyframes bounceFlame {
+  0%, 100%   { transform: translateY(0) scale(1); }
+  25%        { transform: translateY(-4px) scale(1.05); }
+  50%        { transform: translateY(0) scale(1.15); }
+  75%        { transform: translateY(-2px) scale(1.05); }
+}

--- a/static/js/dashboard_middle.js
+++ b/static/js/dashboard_middle.js
@@ -1,0 +1,25 @@
+// === dashboard_middle.js ===
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('✅ dashboard_middle.js loaded');
+
+  const rows = document.querySelectorAll('.row-pair');
+
+  rows.forEach(row => {
+    // Hover effect
+    row.addEventListener('mouseenter', () => {
+      row.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
+      row.style.transform = 'scale(1.01)';
+    });
+
+    row.addEventListener('mouseleave', () => {
+      row.style.boxShadow = '';
+      row.style.transform = '';
+    });
+
+    // Click-to-toggle details (could expand row later)
+    row.addEventListener('click', () => {
+      row.classList.toggle('selected-row');
+      console.log('🧪 Row toggled:', row);
+    });
+  });
+});

--- a/templates/dash_middle.html
+++ b/templates/dash_middle.html
@@ -1,5 +1,8 @@
 <div class="sonic-section-container sonic-section-middle">
-  <div class="section-title">Middle Section</div>
-  <div class="sonic-content-panel">Middle Left</div>
-  <div class="sonic-content-panel">Middle Right</div>
+  <div class="sonic-content-panel middle-left">
+    <!-- Placeholder for positions or other content -->
+  </div>
+  <div class="sonic-content-panel middle-right">
+    {% include "liquidation_bars.html" %}
+  </div>
 </div>

--- a/templates/liquidation_bars.html
+++ b/templates/liquidation_bars.html
@@ -1,0 +1,32 @@
+{# NO inner container, NO title/label row, just bars and badges #}
+{% if liquidation_positions %}
+  {% for pos in liquidation_positions %}
+    {% if pos.travel_percent is defined and pos.travel_percent is not none %}
+      <div class="liq-row d-flex align-items-center" style="gap: 0.6rem; margin-bottom: 0.7rem;">
+        <img src="{{ url_for('static', filename='images/btc_logo.png') }}" alt="A" class="asset-icon" style="width: 28px; height: 28px; border-radius: 50%;" />
+
+        <div class="liq-bar-container" style="flex: 1;">
+          <div class="liq-midline"></div>
+          {% set pct = pos.travel_percent|float %}
+          {% if pct >= 0 %}
+            <div class="liq-bar-fill positive" style="left:50%; width:{{ pct }}%;">
+              <div class="travel-text">{{ pct|round(1) }}%</div>
+            </div>
+          {% else %}
+            <div class="liq-bar-fill negative" style="right:50%; width:{{ pct|abs }}%;">
+              <div class="travel-text">{{ pct|round(1) }}%</div>
+            </div>
+          {% endif %}
+        </div>
+
+        <div class="liq-heat-badge">
+          {{ pos.heat_index|int if pos.heat_index is defined and pos.heat_index is not none else 'N/A' }}
+        </div>
+      </div>
+    {% else %}
+      <p style="color:red;">⚠️ Skipping a position missing travel_percent</p>
+    {% endif %}
+  {% endfor %}
+{% else %}
+  <p style="color:orange;">⚠️ No liquidation positions to display.</p>
+{% endif %}

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -117,6 +117,7 @@
     });
   </script>
   <script src="{{ url_for('static', filename='js/dashboard_top.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/dashboard_middle.js') }}"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script>
     const sizeData = {{ size_composition | tojson }};


### PR DESCRIPTION
## Summary
- reintroduce liquidation bars styles
- add dashboard middle interactions script
- restore liquidation bars html partial
- include bars on dashboard middle section
- load `dashboard_middle.js` on Sonic dashboard

## Testing
- `pytest -q` *(fails: `pytest` not found)*