### PR TITLE
Improve DB viewer

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -314,12 +314,26 @@ def seed_all_thresholds():
 
 @system_bp.route("/database_viewer", methods=["GET"])
 def database_viewer():
+    return render_template("db_viewer.html")
+
+
+@system_bp.route("/database_viewer/datasets", methods=["GET"])
+def database_datasets():
+    dl = current_app.data_locker
     try:
-        datasets = current_app.data_locker.get_all_tables_as_dict()
-        return render_template("system/database_viewer.html", datasets=datasets)
+        return jsonify(dl.get_all_tables_as_dict())
     except Exception as e:
-        flash(f"❌ Error loading DB viewer: {e}", "danger")
-        return render_template("system/database_viewer.html", datasets={})
+        return jsonify({"error": str(e)}), 500
+
+
+@system_bp.route("/database_viewer/<table_name>", methods=["GET"])
+def get_table_data(table_name: str):
+    dl = current_app.data_locker
+    try:
+        rows = dl.get_table_as_dict(table_name)
+        return jsonify(rows)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 @system_bp.route("/xcom_config", methods=["GET"])
 def xcom_config_page():

--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -300,3 +300,22 @@ class DataLocker:
         self.db.commit()
         log.success("✅ Seeded default thresholds", source="DataLocker")
 
+    def get_all_tables_as_dict(self) -> dict:
+        """Return all tables with their rows as lists of dicts."""
+        cursor = self.db.get_cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = [row[0] for row in cursor.fetchall()]
+
+        datasets = {}
+        for tbl in tables:
+            cursor.execute(f"SELECT * FROM {tbl}")
+            datasets[tbl] = [dict(row) for row in cursor.fetchall()]
+
+        return datasets
+
+    def get_table_as_dict(self, table_name: str) -> list:
+        """Return a single table as a list of dicts."""
+        cursor = self.db.get_cursor()
+        cursor.execute(f"SELECT * FROM {table_name}")
+        return [dict(row) for row in cursor.fetchall()]
+

--- a/settings/settings_bp.py
+++ b/settings/settings_bp.py
@@ -44,10 +44,27 @@ def save_theme():
 @settings_bp.route("/database")
 @route_log_alert
 def database_viewer():
+    return render_template("db_viewer.html")
+
+
+@settings_bp.route("/database/datasets")
+@route_log_alert
+def database_datasets():
+    dl = current_app.data_locker
     try:
-        dl = current_app.data_locker
-        datasets = dl.get_all_tables_as_dict()
-        return render_template("database_viewer.html", datasets=datasets)
+        return jsonify(dl.get_all_tables_as_dict())
     except Exception as e:
         log.error(f"❌ Error loading tables: {e}", source="DatabaseViewer")
-        return render_template("database_viewer.html", datasets={})
+        return jsonify({"error": str(e)}), 500
+
+
+@settings_bp.route("/database/<table_name>")
+@route_log_alert
+def get_table_data(table_name):
+    dl = current_app.data_locker
+    try:
+        rows = dl.get_table_as_dict(table_name)
+        return jsonify(rows)
+    except Exception as e:
+        log.error(f"❌ Error fetching table {table_name}: {e}", source="DatabaseViewer")
+        return jsonify({"error": str(e)}), 500

--- a/templates/db_viewer.html
+++ b/templates/db_viewer.html
@@ -13,47 +13,66 @@
   <h2 class="mb-3">Database Viewer</h2>
   <div class="mb-3">
     <label for="tableSelect" class="form-label">Select Table:</label>
-    <select id="tableSelect" class="form-select" onchange="showTable(this.value)">
-      {% for name in datasets.keys() %}
-      <option value="{{ name }}">{{ name }}</option>
-      {% endfor %}
-    </select>
+    <select id="tableSelect" class="form-select"></select>
   </div>
-  <div id="tablesContainer">
-    {% for name, rows in datasets.items() %}
-    <table class="table table-striped table-bordered db-table" id="tbl-{{ name }}" {% if not loop.first %}style="display:none"{% endif %}>
-      <thead>
-        <tr>
-          {% if rows %}
-          {% for col in rows[0].keys() %}
-          <th>{{ col }}</th>
-          {% endfor %}
-          {% else %}
-          <th>No Data</th>
-          {% endif %}
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in rows %}
-        <tr>
-          {% for col in row.keys() %}
-          <td>{{ row[col] }}</td>
-          {% endfor %}
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    {% endfor %}
-  </div>
+  <table class="table table-striped table-bordered db-table" id="dbTable">
+    <thead id="tblHead"></thead>
+    <tbody id="tblBody"></tbody>
+  </table>
 </div>
 {% endblock %}
 
 {% block extra_scripts %}
 <script>
-function showTable(name) {
-  document.querySelectorAll('.db-table').forEach(tbl => {
-    tbl.style.display = tbl.id === 'tbl-' + name ? '' : 'none';
-  });
+async function loadTable(name) {
+  const resp = await fetch(`/system/database_viewer/${name}`);
+  const rows = await resp.json();
+  const head = document.getElementById('tblHead');
+  const body = document.getElementById('tblBody');
+  head.innerHTML = '';
+  body.innerHTML = '';
+  if (rows.length) {
+    const headerRow = document.createElement('tr');
+    Object.keys(rows[0]).forEach(col => {
+      const th = document.createElement('th');
+      th.textContent = col;
+      headerRow.appendChild(th);
+    });
+    head.appendChild(headerRow);
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      Object.values(r).forEach(val => {
+        const td = document.createElement('td');
+        td.textContent = val;
+        tr.appendChild(td);
+      });
+      body.appendChild(tr);
+    });
+  } else {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.textContent = 'No Data';
+    tr.appendChild(td);
+    body.appendChild(tr);
+  }
 }
+
+async function populateTables() {
+  const resp = await fetch('/system/database_viewer/datasets');
+  const data = await resp.json();
+  const select = document.getElementById('tableSelect');
+  Object.keys(data).forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    select.appendChild(opt);
+  });
+  if (select.value) {
+    loadTable(select.value);
+  }
+  select.addEventListener('change', () => loadTable(select.value));
+}
+
+document.addEventListener('DOMContentLoaded', populateTables);
 </script>
 {% endblock %}

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -25,10 +25,10 @@
         <span>⚙️</span>
       </button>
       <ul class="dropdown-menu" aria-labelledby="settingsDropdown">
-        <li><a class="dropdown-item" href="/theme_editor"><span>🎨</span> Theme Builder</a></li>
-        <li><a class="dropdown-item" href="/database"><span>🗃️</span> Database Viewer</a></li>
-        <li><a class="dropdown-item" href="/alert_thresholds"><span>📏</span> Alert Thresholds</a></li>
-        <li><a class="dropdown-item" href="/xcom_config"><span>🔌</span> XCom Config</a></li>
+        <li><a class="dropdown-item" href="/system/themes/editor"><span>🎨</span> Theme Builder</a></li>
+        <li><a class="dropdown-item" href="/system/database_viewer"><span>🗃️</span> Database Viewer</a></li>
+        <li><a class="dropdown-item" href="/system/alert_thresholds"><span>📏</span> Alert Thresholds</a></li>
+        <li><a class="dropdown-item" href="/system/xcom_config"><span>🔌</span> XCom Config</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- implement `get_all_tables_as_dict` and `get_table_as_dict` in DataLocker
- add API endpoints for DB viewer datasets and tables
- rework `db_viewer.html` to fetch tables dynamically
- update settings dropdown links

## Testing
- `pytest -q` *(fails: command not found)*