### PR TITLE
Add Hedge Calculator nav

### DIFF
--- a/sonic_app.py
+++ b/sonic_app.py
@@ -93,6 +93,12 @@ def api_heartbeat():
         })
     return jsonify({"monitors": result})
 
+# --- Hedge Calculator Redirect ---
+@app.route("/hedge_calculator")
+def hedge_calculator_redirect():
+    """Redirect to the Hedge Calculator page within the system blueprint."""
+    return redirect(url_for("system.hedge_calculator_page"))
+
 if "dashboard.index" in app.view_functions:
     app.add_url_rule("/dashboard", endpoint="dash", view_func=app.view_functions["dashboard.index"])
 

--- a/templates/hedge_calculator.html
+++ b/templates/hedge_calculator.html
@@ -3,6 +3,63 @@
 {% block page_title %}{% endblock %}
 
 {% block content %}
-<h1>Hedge Calculator</h1>
-<p>TODO: full hedge calculator content.</p>
+<div class="container mt-4">
+  <h1 class="mb-3">Hedge Calculator</h1>
+
+  <div class="row">
+    <div class="col-md-6">
+      <h3>Long Positions</h3>
+      {% if long_positions %}
+      <table class="table table-sm table-striped">
+        <thead>
+          <tr>
+            <th>Asset</th>
+            <th class="text-end">Size</th>
+            <th class="text-end">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for pos in long_positions %}
+          <tr>
+            <td>{{ pos.asset_type }}</td>
+            <td class="text-end">{{ pos.size }}</td>
+            <td class="text-end">{{ pos.value }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <p><strong>Total: {{ long_positions | sum(attribute='value') }}</strong></p>
+      {% else %}
+      <p>No long positions.</p>
+      {% endif %}
+    </div>
+
+    <div class="col-md-6">
+      <h3>Short Positions</h3>
+      {% if short_positions %}
+      <table class="table table-sm table-striped">
+        <thead>
+          <tr>
+            <th>Asset</th>
+            <th class="text-end">Size</th>
+            <th class="text-end">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for pos in short_positions %}
+          <tr>
+            <td>{{ pos.asset_type }}</td>
+            <td class="text-end">{{ pos.size }}</td>
+            <td class="text-end">{{ pos.value }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <p><strong>Total: {{ short_positions | sum(attribute='value') }}</strong></p>
+      {% else %}
+      <p>No short positions.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -3,6 +3,7 @@
   <div class="left-buttons d-flex gap-2">
     <a class="btn btn-light nav-icon-btn" href="/" title="Home"><span>🏠</span></a>
     <a class="btn btn-light nav-icon-btn" href="/positions" title="Positions"><span>📊</span></a>
+    <a class="btn btn-light nav-icon-btn" href="/hedge_calculator" title="Hedge Calculator"><span>🌿</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
     SONIC DASHBOARD


### PR DESCRIPTION
## Summary
- add hedge calculator icon on the title bar
- support `/hedge_calculator` route that redirects to System hedge calculator page
- load hedge calculator theme and modifier settings from the DB with JSON fallback
- replace placeholder hedge calculator page with table of long and short positions

## Testing
- `pytest -q` *(fails: command not found)*