### PR TITLE
Fix width of liquidation panel container

### DIFF
--- a/static/css/liquidation_bars.css
+++ b/static/css/liquidation_bars.css
@@ -181,6 +181,7 @@
 
 /* Container & label for dashboard version */
 .common-box.liquidation-box {
+  width: 100%;
   padding: 0.8rem 1rem;
   border-radius: 12px;
   background: var(--container-bg, #fff);


### PR DESCRIPTION
## Summary
- ensure the liquidation panel container spans the full width so its contents aren't squished

## Testing
- `pytest -q` *(fails: command not found)*