### PR TITLE
Remove extra container around liquidation panel

### DIFF
--- a/static/css/liquidation_bars.css
+++ b/static/css/liquidation_bars.css
@@ -178,16 +178,7 @@
   font-size: 0.8rem;
 }
 
-
-/* Container & label for dashboard version */
-.common-box.liquidation-box {
-  padding: 0.8rem 1rem;
-  border-radius: 12px;
-  background: var(--container-bg, #fff);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
-  margin-bottom: 1rem;
-}
-
+/* Label for dashboard version */
 .chart-label {
   font-weight: 600;
   margin-bottom: 0.6rem;

--- a/templates/liquidation_bars.html
+++ b/templates/liquidation_bars.html
@@ -1,5 +1,4 @@
-<div class="common-box liquidation-box">
-  <div class="chart-label">Liquidation Bar</div>
+<div class="chart-label">Liquidation Bar</div>
 
   {% if liquidation_positions %}
     {% for pos in liquidation_positions %}
@@ -41,4 +40,3 @@
   {% else %}
     <p style="color:orange;">⚠️ No liquidation positions to display.</p>
   {% endif %}
-</div>


### PR DESCRIPTION
## Summary
- drop the `.common-box.liquidation-box` wrapper so the panel content spans the full width
- clean up related CSS

## Testing
- `pytest -q` *(fails: command not found)*