### PR TITLE
Add Hedge Calculator nav

### DIFF
--- a/sonic_app.py
+++ b/sonic_app.py
@@ -93,6 +93,12 @@ def api_heartbeat():
         })
     return jsonify({"monitors": result})
 
+# --- Hedge Calculator Redirect ---
+@app.route("/hedge_calculator")
+def hedge_calculator_redirect():
+    """Redirect to the Hedge Calculator page within the system blueprint."""
+    return redirect(url_for("system.hedge_calculator_page"))
+
 if "dashboard.index" in app.view_functions:
     app.add_url_rule("/dashboard", endpoint="dash", view_func=app.view_functions["dashboard.index"])
 

--- a/templates/hedge_calculator.html
+++ b/templates/hedge_calculator.html
@@ -1,8 +1,57 @@
 {% extends "base.html" %}
 {% block title %}Hedge Calculator{% endblock %}
-{% block page_title %}{% endblock %}
 
 {% block content %}
-<h1>Hedge Calculator</h1>
-<p>TODO: full hedge calculator content.</p>
+{% include "title_bar.html" %}
+<div class="container py-4">
+  <h2 class="mb-3">Long Positions</h2>
+  <table class="table table-striped table-sm">
+    <thead>
+      <tr>
+        {% if long_positions %}
+          {% for col in long_positions[0].keys() %}
+          <th>{{ col }}</th>
+          {% endfor %}
+        {% else %}
+          <th>No Data</th>
+        {% endif %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in long_positions %}
+      <tr>
+        {% for val in row.values() %}
+        <td>{{ val }}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <p class="fw-bold">Total Value: {{ long_total }}</p>
+
+  <h2 class="mt-4 mb-3">Short Positions</h2>
+  <table class="table table-striped table-sm">
+    <thead>
+      <tr>
+        {% if short_positions %}
+          {% for col in short_positions[0].keys() %}
+          <th>{{ col }}</th>
+          {% endfor %}
+        {% else %}
+          <th>No Data</th>
+        {% endif %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in short_positions %}
+      <tr>
+        {% for val in row.values() %}
+        <td>{{ val }}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <p class="fw-bold">Total Value: {{ short_total }}</p>
+</div>
 {% endblock %}

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -3,6 +3,7 @@
   <div class="left-buttons d-flex gap-2">
     <a class="btn btn-light nav-icon-btn" href="/" title="Home"><span>🏠</span></a>
     <a class="btn btn-light nav-icon-btn" href="/positions" title="Positions"><span>📊</span></a>
+    <a class="btn btn-light nav-icon-btn" href="/hedge_calculator" title="Hedge Calculator"><span>🌿</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
     SONIC DASHBOARD


### PR DESCRIPTION
## Summary
- add hedge calculator icon on the title bar
- support `/hedge_calculator` route that redirects to System hedge calculator page
- render Hedge Calculator using DB-backed theme profile and modifiers
- replace placeholder template with tables showing long and short positions

## Testing
- `pytest -q` *(fails: command not found)*
