### PR TITLE
Adjust monitor card layout

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -36,7 +36,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1.2rem 1.7rem;  /* row gap and column gap */
-  justify-content: flex-start;
+  justify-content: center;   /* center cards within the panel */
   width: 100%;
   margin-top: 1.1rem;
 }
@@ -113,11 +113,11 @@
   margin-bottom: 0.2rem;
 }
 .status-card.monitor-style .value {
-  font-size: 0.95rem;
+  font-size: 0.75rem;       /* smaller numeric value */
   font-weight: 700;         /* bold value text */
 }
 .status-card.monitor-style .label {
-  font-size: 0.55rem;       /* tiny timestamp or secondary label */
+  font-size: 0.9rem;        /* emphasize monitor name */
   line-height: 1.1;
 }
 


### PR DESCRIPTION
## Summary
- tweak `.card-flex` to center monitor cards
- enlarge monitor card label text and shrink value text

## Testing
- `pytest -q` *(fails: command not found)*