### PR TITLE
Fix width of liquidation progress rows

### DIFF
--- a/static/css/liquidation_bars.css
+++ b/static/css/liquidation_bars.css
@@ -140,6 +140,7 @@
   align-items: center;
   gap: 0.75rem;
   margin-bottom: 1rem;
+  width: 100%;
 }
 
 .wallet-icon {


### PR DESCRIPTION
## Summary
- ensure each liquidation row stretches across the content panel

## Testing
- `pytest -q` *(fails: command not found)*