### PR TITLE
Improve monitor card layout

### DIFF
--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -68,7 +68,7 @@ def format_monitor_time(iso_str):
         month = str(pacific.month)
         day = str(pacific.day)
 
-        formatted = f"{hour}:{minute} {ampm} {month}/{day}"
+        formatted = f"{hour}:{minute} {ampm}\n{month}/{day}"
         print(f"DEBUG: Parsed and formatted time: {formatted}")
         return formatted
     except Exception as e:

--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -31,7 +31,8 @@ def format_monitor_time(iso_str):
     try:
         dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
         pacific = dt.astimezone(ZoneInfo("America/Los_Angeles"))
-        return pacific.strftime("%I:%M %p %m/%d").lstrip("0")
+        # format time on one line and date on the next
+        return pacific.strftime("%I:%M %p\n%m/%d").lstrip("0")
     except Exception as e:
         log.error(f"Time formatting failed: {e}", source="DashboardContext")
         return "N/A"
@@ -86,7 +87,7 @@ def format_monitor_time(iso_str):
     try:
         dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
         pacific = dt.astimezone(ZoneInfo("America/Los_Angeles"))
-        return pacific.strftime("%I:%M %p %m/%d").lstrip("0")
+        return pacific.strftime("%I:%M %p\n%m/%d").lstrip("0")
     except Exception as e:
         return "N/A"
 

--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -36,7 +36,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1.2rem 1.7rem;  /* row gap and column gap */
-  justify-content: flex-start;
+  justify-content: space-evenly;  /* spread cards evenly */
   width: 100%;
   margin-top: 1.1rem;
 }
@@ -113,12 +113,14 @@
   margin-bottom: 0.2rem;
 }
 .status-card.monitor-style .value {
-  font-size: 0.95rem;
-  font-weight: 700;         /* bold value text */
+  font-size: 0.75rem;       /* smaller numeric value */
+  font-weight: 400;         /* not bold for timestamp */
+  white-space: pre-line;    /* allow newline between time and date */
 }
 .status-card.monitor-style .label {
-  font-size: 0.55rem;       /* tiny timestamp or secondary label */
+  font-size: 0.9rem;        /* emphasize monitor name */
   line-height: 1.1;
+  margin-bottom: 0.2rem;    /* slight spacing from icon */
 }
 
 /* ─────────────────────────────────────────────── */

--- a/templates/monitor_cards.html
+++ b/templates/monitor_cards.html
@@ -4,11 +4,11 @@
       <div class="flip-card">
         <div class="flip-card-inner">
           <div class="flip-card-front status-card monitor-style {{ item.color }}">
-            <div class="icon">{{ item.icon }}</div>
-            <div class="value">{{ item.value }}</div>
-            <div class="label">{{ item.title }}</div>
-            <div class="led-dot {{ item.color }}"></div>
-          </div>
+              <div class="label">{{ item.title }}</div>
+              <div class="icon">{{ item.icon }}</div>
+              <div class="value">{{ item.value }}</div>
+              <div class="led-dot {{ item.color }}"></div>
+            </div>
           <div class="flip-card-back">
             {% if item.title == "Price" %}
               <strong>Status:</strong>


### PR DESCRIPTION
## Summary
- space monitor cards evenly
- move monitor name above icon
- show timestamp on two lines and not bold

## Testing
- `pytest -q` *(fails: command not found)*