### PR TITLE
Fix chart rendering on Sonic dashboard

### DIFF
--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -120,8 +120,8 @@
   <script src="{{ url_for('static', filename='js/dashboard_middle.js') }}"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script>
-    const graphData = {{ graph_data | tojson }};
-    const sizeData = {{ size_composition | tojson }};
+    window.graphData = {{ graph_data | tojson }};
+    window.sizeData = {{ size_composition | tojson }};
   </script>
   <script src="{{ url_for('static', filename='js/dashboard_bottom.js') }}"></script>
   <script src="{{ url_for('static', filename='js/size_pie.js') }}"></script>


### PR DESCRIPTION
## Summary
- ensure chart data is exposed on `window` so `dashboard_bottom.js` and `size_pie.js` can access it

## Testing
- `pytest -q` *(fails: command not found)*