### PR TITLE
Load both hedge and heat modifiers

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -339,16 +339,23 @@ def hedge_calculator_page():
         # Load the active theme profile from the DB instead of a JSON file
         theme_config = dl.system.get_active_theme_profile() or {}
 
-        # Retrieve hedge calculator modifiers from the modifiers table
-        modifiers = dl.modifiers.get_all_modifiers("hedge_modifiers")
+        # Retrieve hedge and heat modifiers from the modifiers table
+        hedge_mods = dl.modifiers.get_all_modifiers("hedge_modifiers")
+        heat_mods = dl.modifiers.get_all_modifiers("heat_modifiers")
+        modifiers = {"hedge_modifiers": hedge_mods, "heat_modifiers": heat_mods}
 
-        if not modifiers:
-            # Optional fallback to sonic_sauce.json if DB is empty
+        # Fallback to sonic_sauce.json if either group is missing
+        if not hedge_mods or not heat_mods:
             try:
                 json_manager = current_app.json_manager
-                modifiers = json_manager.load("sonic_sauce.json", json_type=JsonType.SONIC_SAUCE)
+                fallback = json_manager.load(
+                    "sonic_sauce.json", json_type=JsonType.SONIC_SAUCE
+                ) or {}
+                hedge_mods = hedge_mods or fallback.get("hedge_modifiers", {})
+                heat_mods = heat_mods or fallback.get("heat_modifiers", {})
+                modifiers = {"hedge_modifiers": hedge_mods, "heat_modifiers": heat_mods}
             except Exception:
-                modifiers = {}
+                pass
 
         return render_template(
             "hedge_calculator.html",

--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -20,14 +20,19 @@ def hedge_calculator():
 
         dl = current_app.data_locker
         theme_config = dl.system.get_active_theme_profile() or {}
-        modifiers = dl.modifiers.get_all_modifiers("hedge_modifiers")
+        hedge_mods = dl.modifiers.get_all_modifiers("hedge_modifiers")
+        heat_mods = dl.modifiers.get_all_modifiers("heat_modifiers")
+        modifiers = {"hedge_modifiers": hedge_mods, "heat_modifiers": heat_mods}
 
-        if not modifiers:
+        if not hedge_mods or not heat_mods:
             try:
                 json_manager = current_app.json_manager
-                modifiers = json_manager.load("sonic_sauce.json", json_type=JsonType.SONIC_SAUCE)
+                fallback = json_manager.load("sonic_sauce.json", json_type=JsonType.SONIC_SAUCE) or {}
+                hedge_mods = hedge_mods or fallback.get("hedge_modifiers", {})
+                heat_mods = heat_mods or fallback.get("heat_modifiers", {})
+                modifiers = {"hedge_modifiers": hedge_mods, "heat_modifiers": heat_mods}
             except Exception:
-                modifiers = {}
+                pass
 
         return render_template("hedge_calculator.html",
                                theme=theme_config,


### PR DESCRIPTION
## Summary
- update `hedge_calculator_page` to fetch heat modifiers alongside hedge modifiers
- do the same for the labs blueprint
- keep fallback to `sonic_sauce.json`

## Testing
- `python -m pip install pytest` *(fails: No route to host)*