### PR TITLE
Fix db viewer table selection

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,5 +11,6 @@
 <body>
   {% block content %}{% endblock %}
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
+  {% block extra_scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include `extra_scripts` block in base template so db_viewer has access to its JS

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*