### PR TITLE
Fix hedge calculator modifiers structure

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -339,16 +339,25 @@ def hedge_calculator_page():
         # Load the active theme profile from the DB instead of a JSON file
         theme_config = dl.system.get_active_theme_profile() or {}
 
-        # Retrieve hedge calculator modifiers from the modifiers table
-        modifiers = dl.modifiers.get_all_modifiers("hedge_modifiers")
+        # Retrieve hedge & heat modifiers from the modifiers table
+        hedge_mods = dl.modifiers.get_all_modifiers("hedge_modifiers")
+        heat_mods = dl.modifiers.get_all_modifiers("heat_modifiers")
 
-        if not modifiers:
+        if not hedge_mods or not heat_mods:
             # Optional fallback to sonic_sauce.json if DB is empty
             try:
                 json_manager = current_app.json_manager
-                modifiers = json_manager.load("sonic_sauce.json", json_type=JsonType.SONIC_SAUCE)
+                sauce = json_manager.load("sonic_sauce.json", json_type=JsonType.SONIC_SAUCE) or {}
+                hedge_mods = hedge_mods or sauce.get("hedge_modifiers", {})
+                heat_mods = heat_mods or sauce.get("heat_modifiers", {})
             except Exception:
-                modifiers = {}
+                hedge_mods = hedge_mods or {}
+                heat_mods = heat_mods or {}
+
+        modifiers = {
+            "hedge_modifiers": hedge_mods,
+            "heat_modifiers": heat_mods,
+        }
 
         return render_template(
             "hedge_calculator.html",

--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -20,14 +20,23 @@ def hedge_calculator():
 
         dl = current_app.data_locker
         theme_config = dl.system.get_active_theme_profile() or {}
-        modifiers = dl.modifiers.get_all_modifiers("hedge_modifiers")
+        hedge_mods = dl.modifiers.get_all_modifiers("hedge_modifiers")
+        heat_mods = dl.modifiers.get_all_modifiers("heat_modifiers")
 
-        if not modifiers:
+        if not hedge_mods or not heat_mods:
             try:
                 json_manager = current_app.json_manager
-                modifiers = json_manager.load("sonic_sauce.json", json_type=JsonType.SONIC_SAUCE)
+                sauce = json_manager.load("sonic_sauce.json", json_type=JsonType.SONIC_SAUCE) or {}
+                hedge_mods = hedge_mods or sauce.get("hedge_modifiers", {})
+                heat_mods = heat_mods or sauce.get("heat_modifiers", {})
             except Exception:
-                modifiers = {}
+                hedge_mods = hedge_mods or {}
+                heat_mods = heat_mods or {}
+
+        modifiers = {
+            "hedge_modifiers": hedge_mods,
+            "heat_modifiers": heat_mods,
+        }
 
         return render_template("hedge_calculator.html",
                                theme=theme_config,


### PR DESCRIPTION
## Summary
- fetch both hedge and heat modifiers for hedge calculator
- build nested `modifiers` dict to match template expectations

## Testing
- `pytest -q` *(fails: No module named pytest)*