### PR TITLE
Fix bottom charts layout and toggle

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -31,6 +31,11 @@
   position: relative;
 }
 
+/* Chart containers should span the full width of the panel */
+.full-chart {
+  width: 100%;
+}
+
 /* Container that holds the cards inside the panel */
 .card-flex {
   display: flex;

--- a/static/js/dashboard_bottom.js
+++ b/static/js/dashboard_bottom.js
@@ -32,6 +32,8 @@ function renderLineChart(data) {
 
   const chartEl = document.querySelector('#lineChart');
   if (!chartEl) return;
+  chartEl.textContent = '';
+  chartEl.style.width = '100%';
   const chart = new ApexCharts(chartEl, options);
   chart.render();
 }

--- a/static/js/size_pie.js
+++ b/static/js/size_pie.js
@@ -24,14 +24,16 @@ window.addEventListener('DOMContentLoaded', () => {
   };
 
   const chartEl = document.querySelector('#pieChartSize');
+  if (!chartEl) return;
+  chartEl.textContent = '';
+  chartEl.style.width = '100%';
+  chartEl.style.cursor = 'pointer';
+
   const chart = new ApexCharts(chartEl, options);
   chart.render();
 
-  const btn = document.getElementById('togglePieMode');
-  if (btn) {
-    btn.addEventListener('click', () => {
-      mode = mode === 'donut' ? 'pie' : 'donut';
-      chart.updateOptions({ chart: { type: mode } });
-    });
-  }
+  chartEl.addEventListener('click', () => {
+    mode = mode === 'donut' ? 'pie' : 'donut';
+    chart.updateOptions({ chart: { type: mode } });
+  });
 });

--- a/templates/dash_bottom.html
+++ b/templates/dash_bottom.html
@@ -1,10 +1,9 @@
 <div class="sonic-section-container sonic-section-bottom">
   <div class="sonic-content-panel">
-    <div id="lineChart" style="min-height:300px">Loading...</div>
+    <div id="lineChart" class="full-chart" style="min-height:300px">Loading...</div>
   </div>
   <div class="sonic-content-panel">
-    <div id="pieChartSize" class="mb-2">Loading...</div>
-    <button id="togglePieMode" class="btn btn-outline-secondary btn-sm">Toggle Chart Type</button>
+    <div id="pieChartSize" class="mb-2 full-chart">Loading...</div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- make bottom charts span the full panel
- remove toggle button and toggle pie chart by clicking graph
- clear `Loading...` text after charts render

## Testing
- `pytest -q` *(fails: command not found)*