### PR TITLE
Fix missing CalculationCore.calculate_totals

### DIFF
--- a/calc_core/calculation_core.py
+++ b/calc_core/calculation_core.py
@@ -114,3 +114,7 @@ class CalculationCore:
         for key, value in heat_mods.items():
             self.set_modifier(key, float(value))
         log.success("📦 Modifiers imported from JSON", source="CalculationCore")
+
+    def calculate_totals(self, positions: list) -> dict:
+        """Return aggregated totals for the provided positions."""
+        return self.calc_services.calculate_totals(positions)


### PR DESCRIPTION
## Summary
- add calculate_totals wrapper method so other services can call it

## Testing
- `pytest -q` *(fails: command not found)*