### PR TITLE
Fix db viewer title bar and add themed background

### DIFF
--- a/static/css/page_sections.css
+++ b/static/css/page_sections.css
@@ -1,0 +1,5 @@
+/* Common styles for page containers with translucent background */
+.page-container {
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 1rem;
+}

--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -8,7 +8,7 @@
 
 
 {% block content %}
-<div class="container py-4">
+<div class="container py-4 page-container">
   <h1 class="mb-4">Alert Limits</h1>
   <p>This page will hold alert configuration options.</p>
 </div>
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid pt-4">
+<div class="container-fluid pt-4 page-container">
 
 <form id="alertForm" method="POST" action="{{ url_for('alerts_bp.update_config') }}">
 

--- a/templates/alert_matrix.html
+++ b/templates/alert_matrix.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid pt-4">
+<div class="container-fluid pt-4 page-container">
 
   <!-- Alert Matrix Card -->
   <div class="card alert-matrix-card">

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
   <title>{% block title %}New Sonic Dashboard{% endblock %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% block head %}{% endblock %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/page_sections.css') }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>

--- a/templates/db_viewer.html
+++ b/templates/db_viewer.html
@@ -3,14 +3,23 @@
 {% block title %}Database Viewer{% endblock %}
 
 {% block head %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
   <style>
-    .db-table { margin-top: 1rem; }
+    body {
+      background-image: url('{{ url_for('static', filename='images/database_wall.jpg') }}');
+      background-size: cover;
+      background-attachment: fixed;
+      background-repeat: no-repeat;
+      background-position: center;
+    }
+    .db-table { margin-top: 1rem; background: #fff; }
   </style>
 {% endblock %}
 
 {% block content %}
 {% include "title_bar.html" %}
-<div class="container py-4">
+<div class="container py-4 page-container">
   <h2 class="mb-3">Database Viewer</h2>
   <div class="mb-3">
     <label for="tableSelect" class="form-label">Select Table:</label>
@@ -50,6 +59,7 @@
 {% endblock %}
 
 {% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
 <script>
 function showTable(name) {
   document.querySelectorAll('.db-table').forEach(tbl => {

--- a/templates/hedge_calculator.html
+++ b/templates/hedge_calculator.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid">
+<div class="container-fluid page-container">
   <!-- Display Mode Radio Buttons -->
   <div class="d-flex justify-content-center mb-3" id="displayModeControls">
     <div class="btn-group" role="group">


### PR DESCRIPTION
## Summary
- add title bar styles and theme links to db_viewer
- show database wall background
- keep section container translucent but tables solid
- load title bar javascript so controls work
- add global translucent section style

## Testing
- `pytest -q` *(fails: command not found)*