### PR TITLE
Remove extra page container classes

### DIFF
--- a/static/css/page_sections.css
+++ b/static/css/page_sections.css
@@ -1,5 +1,0 @@
-/* Common styles for page containers with translucent background */
-.page-container {
-  background: rgba(255, 255, 255, 0.6);
-  border-radius: 1rem;
-}

--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -6,7 +6,8 @@
   margin: 2.5rem auto 2rem auto;      /* top, left/right auto, bottom spacing */
   padding: 0;
   max-width: 1200px;                 /* default max width unless layout mode overrides */
-  background: transparent;
+  background: rgba(255, 255, 255, 0.6); /* translucent */
+  border-radius: 1rem;
   border: none;
   display: flex;
   gap: 2rem;                         /* spacing between .sonic-content-panel items */

--- a/static/css/sonic_themes.css
+++ b/static/css/sonic_themes.css
@@ -132,11 +132,6 @@ body {
   color: var(--text) !important;
   transition: background 0.25s, color 0.25s;
 }
-.sonic-section-container {
-  background: transparent !important;
-=======
-}
-
 :root[data-theme="funky"] {
   --bg: #1e1e40;
   --text: #ffec99;
@@ -216,11 +211,14 @@ body {
 }
 
 /* === Sonic Dashboard Elements === */
-.sonic-content-panel,
-.sonic-section-container {
+.sonic-content-panel {
   background: var(--card-bg) !important;
   color: var(--text) !important;
   transition: background 0.25s, color 0.25s;
+}
+.sonic-section-container {
+  background: rgba(255, 255, 255, 0.6) !important;
+  border-radius: 1rem;
 }
 
 .layout-toggle-btn,

--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -8,7 +8,7 @@
 
 
 {% block content %}
-<div class="container py-4 page-container">
+<div class="container py-4">
   <h1 class="mb-4">Alert Limits</h1>
   <p>This page will hold alert configuration options.</p>
 </div>
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid pt-4 page-container">
+<div class="container-fluid pt-4">
 
 <form id="alertForm" method="POST" action="{{ url_for('alerts_bp.update_config') }}">
 

--- a/templates/alert_matrix.html
+++ b/templates/alert_matrix.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid pt-4 page-container">
+<div class="container-fluid pt-4">
 
   <!-- Alert Matrix Card -->
   <div class="card alert-matrix-card">

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
   {% block head %}{% endblock %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/page_sections.css') }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>

--- a/templates/db_viewer.html
+++ b/templates/db_viewer.html
@@ -13,13 +13,17 @@
       background-repeat: no-repeat;
       background-position: center;
     }
+    .db-viewer-container {
+      background: rgba(255, 255, 255, 0.6);
+      border-radius: 1rem;
+    }
     .db-table { margin-top: 1rem; background: #fff; }
   </style>
 {% endblock %}
 
 {% block content %}
 {% include "title_bar.html" %}
-<div class="container py-4 page-container">
+<div class="container py-4 db-viewer-container">
   <h2 class="mb-3">Database Viewer</h2>
   <div class="mb-3">
     <label for="tableSelect" class="form-label">Select Table:</label>

--- a/templates/hedge_calculator.html
+++ b/templates/hedge_calculator.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid page-container">
+<div class="container-fluid">
   <!-- Display Mode Radio Buttons -->
   <div class="d-flex justify-content-center mb-3" id="displayModeControls">
     <div class="btn-group" role="group">


### PR DESCRIPTION
## Summary
- drop global `page_sections.css` and remove references
- revert page container divs to original classes
- style `.sonic-section-container` with a translucent background

## Testing
- `pytest -q` *(fails: command not found)*