### PR TITLE
Fix template closing tags

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -154,12 +154,11 @@
   </div>
 </div>
 
-<!-- (continues...) -->
+  <!-- (continues...) -->
 
-{% endif %}
-{% endif %}
-{% endif %}
-{% endblock %}
+</div>
+</form>
+</div>
 {% endblock %}
 
 


### PR DESCRIPTION
## Summary
- clean up stray Jinja tags in `alert_limits.html`
- close the form and container div at the end of the page

## Testing
- `pip install jinja2` *(fails: Could not find a version that satisfies the requirement)*