### PR TITLE
Add alert matrix page link

### DIFF
--- a/app/alerts_bp.py
+++ b/app/alerts_bp.py
@@ -166,6 +166,25 @@ def monitor_page():
     return render_template("alert_monitor.html")
 
 
+@alerts_bp.route('/alert_matrix', methods=['GET'])
+def alert_matrix_page():
+    """Render the Alert Matrix page."""
+    alerts = []
+    hedges = []
+    try:
+        dl = current_app.data_locker
+        alerts = dl.alerts.get_all_alerts()
+    except Exception as e:
+        logger.error(f"Failed to load alerts for matrix: {e}", exc_info=True)
+    # Hedging data may not be available yet; attempt if method exists
+    try:
+        if hasattr(dl, 'portfolio') and hasattr(dl.portfolio, 'get_hedges'):
+            hedges = dl.portfolio.get_hedges()
+    except Exception as e:
+        logger.warning(f"Failed to load hedges: {e}")
+    return render_template('alert_matrix.html', alerts=alerts, hedges=hedges)
+
+
 
 @alerts_bp.route('/monitor', methods=['GET'])
 def monitor_data():

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -5,6 +5,7 @@
     <a class="btn btn-light nav-icon-btn" href="/positions" title="Positions"><span>📊</span></a>
     <a class="btn btn-light nav-icon-btn" href="/hedge_calculator" title="Hedge Calculator"><span>🌿</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/alert_thresholds" title="Alert Limits"><span>🚨</span></a>
+    <a class="btn btn-light nav-icon-btn" href="/alerts/alert_matrix" title="Alert Matrix"><span>🎛️</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
     SONIC DASHBOARD


### PR DESCRIPTION
## Summary
- add `/alert_matrix` route in `alerts_bp`
- fetch alerts and hedges when rendering alert matrix page
- add Alert Matrix icon to the title bar

## Testing
- `pytest -q` *(fails: `pytest` command not found)*