### PR TITLE
Fix Sonic section container color for themes

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -6,7 +6,7 @@
   margin: 2.5rem auto 2rem auto;      /* top, left/right auto, bottom spacing */
   padding: 0;
   max-width: 1200px;                 /* default max width unless layout mode overrides */
-  background: rgba(255, 255, 255, 0.6); /* translucent */
+  background: var(--container-bg, rgba(255, 255, 255, 0.6));
   border-radius: 1rem;
   border: none;
   display: flex;

--- a/static/css/sonic_themes.css
+++ b/static/css/sonic_themes.css
@@ -217,7 +217,7 @@ body {
   transition: background 0.25s, color 0.25s;
 }
 .sonic-section-container {
-  background: rgba(255, 255, 255, 0.6) !important;
+  background: var(--container-bg);
   border-radius: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- use `--container-bg` variable for section container background
- make container theme-aware without hardcoded translucency

## Testing
- `pytest -q` *(fails: command not found)*