### PR TITLE
Make middle panels equal height

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -6,13 +6,13 @@
   margin: 2.5rem auto 2rem auto;      /* top, left/right auto, bottom spacing */
   padding: 0;
   max-width: 1200px;                 /* default max width unless layout mode overrides */
-  background: rgba(255, 255, 255, 0.6); /* translucent */
+  background: var(--container-bg, rgba(255, 255, 255, 0.6));
   border-radius: 1rem;
   border: none;
   display: flex;
   gap: 2rem;                         /* spacing between .sonic-content-panel items */
   justify-content: center;
-  align-items: flex-start;
+  align-items: stretch;
 }
 
 /* Individual Panel in Each Section */

--- a/static/css/sonic_themes.css
+++ b/static/css/sonic_themes.css
@@ -217,7 +217,7 @@ body {
   transition: background 0.25s, color 0.25s;
 }
 .sonic-section-container {
-  background: rgba(255, 255, 255, 0.6) !important;
+  background: var(--container-bg);
   border-radius: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- stretch sonic dashboard section containers so panels match height

## Testing
- `pytest -q` *(fails: command not found)*