### PR TITLE
Add alert matrix page link

### DIFF
--- a/app/alerts_bp.py
+++ b/app/alerts_bp.py
@@ -166,6 +166,25 @@ def monitor_page():
     return render_template("alert_monitor.html")
 
 
+@alerts_bp.route('/alert_matrix', methods=['GET'])
+def alert_matrix_page():
+    """Render the Alert Matrix page."""
+    alerts = []
+    hedges = []
+    try:
+        dl = current_app.data_locker
+        alerts = dl.alerts.get_all_alerts()
+    except Exception as e:
+        logger.error(f"Failed to load alerts for matrix: {e}", exc_info=True)
+    # Hedging data may not be available yet; attempt if method exists
+    try:
+        if hasattr(dl, 'portfolio') and hasattr(dl.portfolio, 'get_hedges'):
+            hedges = dl.portfolio.get_hedges()
+    except Exception as e:
+        logger.warning(f"Failed to load hedges: {e}")
+    return render_template('alert_matrix.html', alerts=alerts, hedges=hedges)
+
+
 
 @alerts_bp.route('/monitor', methods=['GET'])
 def monitor_data():

--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -2,7 +2,7 @@
   background-color: var(--title-bar-bg, #f8f4ff);
   color: var(--text, #232946);
   border-bottom: 1px solid #ccc;
-  min-height: 56px;
+  min-height: 74px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -21,9 +21,9 @@
   align-items: center;
   justify-content: center;
   padding: 0.18rem 0.55rem;
-  font-size: 1.3rem;
-  min-width: 36px;
-  min-height: 36px;
+  font-size: 1.6rem;
+  min-width: 42px;
+  min-height: 42px;
   border-radius: 10px;
   outline: none !important;
   box-shadow: none !important;
@@ -72,7 +72,7 @@
   border-color: #7c3aed;
 }
 .cyclone-btn {
-  font-size: 1.3rem;
+  font-size: 1.6rem;
   border-radius: 8px;
   padding: 0.18rem 0.7rem;
   margin-left: 0.18rem;

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -5,9 +5,9 @@
     <a class="btn btn-light nav-icon-btn" href="/positions" title="Positions"><span>📊</span></a>
     <a class="btn btn-light nav-icon-btn" href="/hedge_calculator" title="Hedge Calculator"><span>🌿</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/alert_thresholds" title="Alert Limits"><span>🚨</span></a>
+    <a class="btn btn-light nav-icon-btn" href="/alerts/alert_matrix" title="Alert Matrix"><span>🎛️</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
-    SONIC DASHBOARD
   </div>
   <div class="title-bar-actions d-flex align-items-center gap-2">
     <button class="btn btn-outline-primary cyclone-btn" data-action="sync"   title="Jupiter Sync">🪐</button>


### PR DESCRIPTION
## Summary
- add `/alert_matrix` route in `alerts_bp`
- fetch alerts and hedges when rendering alert matrix page
- add Alert Matrix icon to the title bar
- enlarge the title bar and icons
- remove Sonic Dashboard title

## Testing
- `pytest -q` *(fails: `pytest` command not found)*