### PR TITLE
Fix alert limits template duplicate block

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -6,14 +6,6 @@
 
 {% block title %}Alert Limits Configuration{% endblock %}
 
-
-{% block content %}
-<div class="container py-4">
-  <h1 class="mb-4">Alert Limits</h1>
-  <p>This page will hold alert configuration options.</p>
-</div>
-{% endblock %}
-
 {% block extra_styles %}
 {{ super() }}
 <style>
@@ -35,6 +27,8 @@
 
 {% block content %}
 <div class="container-fluid pt-4">
+  <h1 class="mb-4">Alert Limits</h1>
+  <p>This page will hold alert configuration options.</p>
 
 <form id="alertForm" method="POST" action="{{ url_for('alerts_bp.update_config') }}">
 


### PR DESCRIPTION
## Summary
- fix `alert_limits.html` by removing duplicate `content` block
- keep the heading inside the main content section

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*