### PR TITLE
Fix alert limits config defaults

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -6,14 +6,6 @@
 
 {% block title %}Alert Limits Configuration{% endblock %}
 
-
-{% block content %}
-<div class="container py-4">
-  <h1 class="mb-4">Alert Limits</h1>
-  <p>This page will hold alert configuration options.</p>
-</div>
-{% endblock %}
-
 {% block extra_styles %}
 {{ super() }}
 <style>
@@ -35,6 +27,8 @@
 
 {% block content %}
 <div class="container-fluid pt-4">
+  <h1 class="mb-4">Alert Limits</h1>
+  <p>This page will hold alert configuration options.</p>
 
 <form id="alertForm" method="POST" action="{{ url_for('alerts_bp.update_config') }}">
 
@@ -44,9 +38,10 @@
   <div class="card-header bg-primary text-white">
     <i class="fas fa-dollar-sign me-2"></i>Price Alerts
   </div>
-  <div class="card-body">
+        <div class="card-body">
     <div class="row">
       {% for asset in ["BTC", "ETH", "SOL"] %}
+      {% set asset_conf = price_alerts.get(asset, {}) %}
       <div class="col-md-4 mb-4">
         <div class="card h-100 text-center shadow-sm">
           <div class="card-body">
@@ -62,19 +57,19 @@
             <label class="form-label mt-3">Trigger Value:</label>
             <input type="number" step="0.01" class="form-control"
                    name="alert_ranges[price_alerts][{{ asset }}][trigger_value]"
-                   value="{{ price_alerts[asset].trigger_value if price_alerts[asset] else '' }}">
+                   value="{{ asset_conf.get('trigger_value', '') }}">
 
             <label class="form-label mt-3">Condition:</label>
             <select class="form-select" name="alert_ranges[price_alerts][{{ asset }}][condition]">
-              <option value="ABOVE" {% if price_alerts[asset].condition == 'ABOVE' %}selected{% endif %}>Above</option>
-              <option value="BELOW" {% if price_alerts[asset].condition == 'BELOW' %}selected{% endif %}>Below</option>
+              <option value="ABOVE" {% if asset_conf.get('condition') == 'ABOVE' %}selected{% endif %}>Above</option>
+              <option value="BELOW" {% if asset_conf.get('condition') == 'BELOW' %}selected{% endif %}>Below</option>
             </select>
 
             <div class="form-check form-switch mt-3">
               <input type="hidden" name="alert_ranges[price_alerts][{{ asset }}][enabled]" value="false">
               <input type="checkbox" class="form-check-input"
                      name="alert_ranges[price_alerts][{{ asset }}][enabled]" value="true"
-                     {% if price_alerts[asset].enabled %}checked{% endif %}>
+                     {% if asset_conf.get('enabled') %}checked{% endif %}>
               <label class="form-check-label">Enabled</label>
             </div>
 
@@ -96,7 +91,7 @@
       <input type="hidden" name="global_alert_config[enabled]" value="false">
       <input type="checkbox" class="form-check-input"
              name="global_alert_config[enabled]" value="true"
-             {% if global_alert_config.enabled %}checked{% endif %}>
+             {% if global_alert_config.get('enabled') %}checked{% endif %}>
       <label class="form-check-label">Enable Global Alerts</label>
     </div>
 
@@ -109,7 +104,7 @@
             <input type="hidden" name="global_alert_config[data_fields][{{ field }}]" value="false">
             <input type="checkbox" class="form-check-input"
                    name="global_alert_config[data_fields][{{ field }}]" value="true"
-                   {% if global_alert_config.data_fields[field] %}checked{% endif %}>
+                   {% if global_alert_config.get('data_fields', {}).get(field) %}checked{% endif %}>
             <label class="form-check-label text-capitalize">{{ field.replace('_',' ') }}</label>
           </div>
 {% endfor %}
@@ -121,17 +116,17 @@
       <div class="col-md-4">
         <label class="form-label">Profit Threshold</label>
         <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][profit]"
-               value="{{ global_alert_config.thresholds.profit }}">
+               value="{{ global_alert_config.get('thresholds', {}).get('profit', '') }}">
       </div>
       <div class="col-md-4">
         <label class="form-label">Travel Threshold</label>
         <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][travel_percent]"
-               value="{{ global_alert_config.thresholds.travel_percent }}">
+               value="{{ global_alert_config.get('thresholds', {}).get('travel_percent', '') }}">
       </div>
       <div class="col-md-4">
         <label class="form-label">Heat Index Threshold</label>
         <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][heat_index]"
-               value="{{ global_alert_config.thresholds.heat_index }}">
+               value="{{ global_alert_config.get('thresholds', {}).get('heat_index', '') }}">
       </div>
     </div>
 
@@ -140,11 +135,12 @@
         <label class="form-label">Price Thresholds per Asset:</label>
         <div class="row g-2">
           {% for asset in ["BTC", "ETH", "SOL"] %}
+          {% set price_conf = global_alert_config.get('thresholds', {}).get('price', {}) %}
           <div class="col-md-4">
             <label class="form-label">{{ asset }}</label>
             <input type="number" step="0.01" class="form-control"
                    name="global_alert_config[thresholds][price][{{ asset }}]"
-                   value="{{ global_alert_config.thresholds.price[asset] }}">
+                   value="{{ price_conf.get(asset, '') }}">
           </div>
 {% endfor %}
         </div>


### PR DESCRIPTION
## Summary
- handle missing keys in `alert_limits.html`
- ensure undefined config data doesn't break rendering

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*