### PR TITLE
Make dashboard section containers transparent

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -6,7 +6,7 @@
   margin: 2.5rem auto 2rem auto;      /* top, left/right auto, bottom spacing */
   padding: 0;
   max-width: 1200px;                 /* default max width unless layout mode overrides */
-  background: var(--container-bg, rgba(255, 255, 255, 0.6));
+  background: transparent;           /* allow page background to show through */
   border-radius: 1rem;
   border: none;
   display: flex;

--- a/static/css/sonic_themes.css
+++ b/static/css/sonic_themes.css
@@ -217,7 +217,7 @@ body {
   transition: background 0.25s, color 0.25s;
 }
 .sonic-section-container {
-  background: var(--container-bg);
+  background: transparent; /* show body background behind each section */
   border-radius: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- update CSS so sonic dashboard sections are transparent

## Testing
- `pytest -q` *(fails: command not found)*