### PR TITLE
Fix title bar icon styles

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -37,8 +37,9 @@
   border-color: #bcb4ef;
 }
 .layout-toggle-btn {
-  border-radius: 7px;
-  font-size: 1.05rem;
+  border-radius: 10px;
+  border: 1.5px solid #d2cdf7;
+  font-size: 1.1rem;
   padding: 0.32em 1em;
   margin-left: 1rem;
 }
@@ -49,13 +50,15 @@
   vertical-align: middle;
 }
 .theme-btn {
-  border: 2px solid #bbb;
-  border-radius: 50%;
+  border: 1.5px solid #d2cdf7;
+  border-radius: 10px;
   padding: 0.34em 0.66em;
-  font-size: 1.26em;
+  font-size: 1.4em;
   background: #fff;
   color: #444;
   cursor: pointer;
+  min-width: 42px;
+  min-height: 42px;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
   outline: none;
 }
@@ -72,12 +75,14 @@
   border-color: #7c3aed;
 }
 .cyclone-btn {
-  font-size: 1.8rem;
-  border-radius: 8px;
-  padding: 0.18rem 0.7rem;
+  font-size: 1.9rem;
+  border-radius: 10px;
+  padding: 0.18rem 0.55rem;
   margin-left: 0.18rem;
   background: #fff;
   border: 1.5px solid #d2cdf7;
+  min-width: 42px;
+  min-height: 42px;
   transition: background 0.18s, color 0.18s, border 0.18s;
 }
 .cyclone-btn:hover {

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -10,10 +10,10 @@
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
   </div>
   <div class="title-bar-actions d-flex align-items-center gap-2">
-    <button class="btn cyclone-btn" data-action="sync"   title="Jupiter Sync">🪐</button>
-    <button class="btn cyclone-btn" data-action="market" title="Market Update">💲</button>
-    <button class="btn cyclone-btn"    data-action="full"   title="Full Cycle">🌪️</button>
-    <button class="btn cyclone-btn"  data-action="wipe"   title="Wipe All">🗑️</button>
+    <button class="btn nav-icon-btn cyclone-btn" data-action="sync"   title="Jupiter Sync">🪐</button>
+    <button class="btn nav-icon-btn cyclone-btn" data-action="market" title="Market Update">💲</button>
+    <button class="btn nav-icon-btn cyclone-btn" data-action="full"  title="Full Cycle">🌪️</button>
+    <button class="btn nav-icon-btn cyclone-btn" data-action="wipe"  title="Wipe All">🗑️</button>
     <button id="layoutModeToggle" class="btn btn-outline-primary layout-toggle-btn" title="Switch View Mode">
       🛠 <span id="currentLayoutMode">wide</span>
     </button>


### PR DESCRIPTION
## Summary
- add containers to cyclone action buttons
- unify layout toggle and theme button styles
- make icon fonts larger while keeping the container size

## Testing
- `pytest -q` *(fails: command not found)*