### PR TITLE
Improve monitor card time display

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -132,10 +132,23 @@
   margin-bottom: 0.2rem;
 }
 .status-card.monitor-style .value {
-  font-size: 0.75rem;       /* smaller numeric value */
-  font-weight: 400;         /* not bold for timestamp */
-  white-space: pre-line;    /* allow newline between time and date */
+  font-size: 0.85rem;       /* slightly larger time */
+  font-weight: 600;         /* emphasize timestamp */
+  white-space: normal;      /* spans manage layout */
+}
 
+.status-card.monitor-style .monitor-time {
+  display: block;
+}
+
+.status-card.monitor-style .monitor-date {
+  display: none;
+  font-size: 0.75rem;
+  font-weight: 400;
+}
+
+.status-card.monitor-style .value:hover .monitor-date {
+  display: block;
 }
 .status-card.monitor-style .label {
   font-size: 0.9rem;        /* emphasize monitor name */

--- a/templates/monitor_cards.html
+++ b/templates/monitor_cards.html
@@ -6,7 +6,10 @@
           <div class="flip-card-front status-card monitor-style {{ item.color }}">
               <div class="label">{{ item.title }}</div>
               <div class="icon">{{ item.icon }}</div>
-              <div class="value">{{ item.value }}</div>
+              <div class="value">
+                <span class="monitor-time">{{ item.value.split('\n')[0] }}</span>
+                <span class="monitor-date">{{ item.value.split('\n')[1] }}</span>
+              </div>
               <div class="led-dot {{ item.color }}"></div>
             </div>
           <div class="flip-card-back">


### PR DESCRIPTION
## Summary
- show time and date in separate spans on monitor cards
- hide date until hovered
- adjust monitor card CSS for larger bold time

## Testing
- `pytest -q` *(fails: command not found)*