### PR TITLE
Move portfolio card labels to top and bold

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -122,7 +122,9 @@
 }
 .label {
   font-family: 'Orbitron', sans-serif;
-  font-size: 0.85rem;       /* label below value (e.g., "Leverage") */
+  font-size: 0.85rem;       /* label text */
+  font-weight: 600;         /* make label bold */
+  margin-bottom: 0.2rem;    /* spacing when label on top */
 }
 
 /* ─────────────────────────────────────────────── */

--- a/templates/portfolio_cards.html
+++ b/templates/portfolio_cards.html
@@ -4,9 +4,9 @@
       <div class="flip-card">
         <div class="flip-card-inner">
           <div class="flip-card-front status-card {{ item.color }}">
+            <div class="label">{{ item.title }}</div>
             <div class="icon">{{ item.icon }}</div>
             <div class="value">{{ item.value }}</div>
-            <div class="label">{{ item.title }}</div>
           </div>
           <div class="flip-card-back">
             {% set thresholds = portfolio_limits.get(item.title.lower().replace(' ', '_'), {}) %}


### PR DESCRIPTION
## Summary
- move portfolio status card labels to the top like monitor cards
- make all labels bold with a bit of spacing

## Testing
- `pytest -q` *(fails: pytest not installed)*