### PR TITLE
Fix hedge calculator data injection

### DIFF
--- a/templates/hedge_calculator.html
+++ b/templates/hedge_calculator.html
@@ -120,7 +120,11 @@
 
       <!-- Simplified output rows omitted for brevity -->
     </div>
-  </div>
 </div>
+</div>
+<script>
+  window.longPositionsData = {{ long_positions | tojson }};
+  window.shortPositionsData = {{ short_positions | tojson }};
+</script>
 <script src="{{ url_for('static', filename='js/hedge_calculator.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expose position data to the hedge calculator JS so dropdowns can be populated

## Testing
- `pytest -q` *(fails: command not found)*