### PR TITLE
Fix title bar button alignment

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -39,21 +39,19 @@
 .layout-toggle-btn {
   border-radius: 10px;
   border: 1.5px solid #d2cdf7;
-  font-size: 1.1rem;
-  padding: 0.32em 1em;
-  margin-left: 1rem;
+  font-size: 1.6rem;
+  padding: 0.18rem 0.55rem;
 }
 .theme-toggle-group {
   display: inline-flex;
   gap: 0.22rem;
-  margin-left: 0.9rem;
   vertical-align: middle;
 }
 .theme-btn {
   border: 1.5px solid #d2cdf7;
   border-radius: 10px;
-  padding: 0.34em 0.66em;
-  font-size: 1.4em;
+  padding: 0.18rem 0.55rem;
+  font-size: 1.6rem;
   background: #fff;
   color: #444;
   cursor: pointer;
@@ -75,10 +73,9 @@
   border-color: #7c3aed;
 }
 .cyclone-btn {
-  font-size: 1.9rem;
+  font-size: 1.6rem;
   border-radius: 10px;
   padding: 0.18rem 0.55rem;
-  margin-left: 0.18rem;
   background: #fff;
   border: 1.5px solid #d2cdf7;
   min-width: 42px;

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -14,13 +14,13 @@
       <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="market" title="Market Update"><span>💲</span></a>
       <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="full"  title="Full Cycle"><span>🌪️</span></a>
       <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="wipe"  title="Wipe All"><span>🗑️</span></a>
-      <a id="layoutModeToggle" class="btn btn-outline-primary layout-toggle-btn" href="#" role="button" title="Switch View Mode">
+      <a id="layoutModeToggle" class="btn btn-outline-primary nav-icon-btn layout-toggle-btn" href="#" role="button" title="Switch View Mode">
         🛠 <span id="currentLayoutMode">wide</span>
       </a>
       <div class="theme-toggle-group" id="themeToggleGroup">
-        <a class="btn btn-outline-secondary theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
-        <a class="btn btn-outline-secondary theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
-        <a class="btn btn-outline-secondary theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
+        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
+        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
+        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
       </div>
       <div class="dropdown ms-2">
         <a class="btn btn-light nav-icon-btn dropdown-toggle" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">


### PR DESCRIPTION
## Summary
- standardize right-side title bar buttons
- match cyclone, layout toggle, and theme buttons to `nav-icon-btn`

## Testing
- `pytest -q` *(fails: command not found)*