### PR TITLE
Add title bar to alert monitor

### DIFF
--- a/app/alert_monitor/alert_monitor.html
+++ b/app/alert_monitor/alert_monitor.html
@@ -3,10 +3,14 @@
 {% block title %}📊 Alert Monitor{% endblock %}
 
 {% block extra_styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
   <link rel="stylesheet" href="{{ url_for('alerts_bp.static', filename='alert_monitor.css') }}">
 {% endblock %}
 
 {% block content %}
+  {% include "title_bar.html" %}
   <div class="container-fluid pt-2">
     <h2>📊 Alert Progress Monitor</h2>
     <div id="alertList"></div>
@@ -14,5 +18,6 @@
 {% endblock %}
 
 {% block extra_scripts %}
+  <script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
   <script src="{{ url_for('alerts_bp.static', filename='alert_monitor.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure Alert Monitor template includes the standard title bar
- add title bar CSS/JS to the page so it matches the rest of the site

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohappyeyeballs)*
- `pytest -q` *(fails: command not found)*