### PR TITLE
Update cyclone button layout

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -72,20 +72,31 @@
   color: #7c3aed;
   border-color: #7c3aed;
 }
+.cyclone-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #cce5ff;
+  border-radius: 50px;
+  box-shadow: inset 0 0 5px #ffa726;
+  padding: 0.75rem 1.25rem;
+  width: fit-content;
+  margin: auto;
+  gap: 1rem;
+}
 .cyclone-btn {
-  font-size: 1.6rem;
-  border-radius: 10px;
-  padding: 0.18rem 0.55rem;
+  font-size: 1.5rem;
+  padding: 0.4rem 0.6rem;
+  border: none;
+  border-radius: 50%;
   background: #fff;
-  border: 1.5px solid #d2cdf7;
-  min-width: 42px;
-  min-height: 42px;
-  transition: background 0.18s, color 0.18s, border 0.18s;
+  cursor: pointer;
+  transition: transform 0.2s ease;
 }
 .cyclone-btn:hover {
-  transform: translateY(-1px) scale(1.09);
-  box-shadow: 0 2px 12px rgba(56,56,112,0.08);
-  background: #f6edff;
-  color: #7c3aed;
-  border-color: #bcb4ef;
+  background: #fff;
+  color: inherit;
+  border-color: transparent;
+  box-shadow: none;
+  transform: scale(1.15);
 }

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -9,29 +9,34 @@
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
   </div>
-    <div class="title-bar-actions d-flex align-items-center gap-2">
-      <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="sync"   title="Jupiter Sync"><span>🪐</span></a>
-      <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="market" title="Market Update"><span>💲</span></a>
-      <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="full"  title="Full Cycle"><span>🌪️</span></a>
-      <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="wipe"  title="Wipe All"><span>🗑️</span></a>
-      <a id="layoutModeToggle" class="btn btn-outline-primary nav-icon-btn layout-toggle-btn" href="#" role="button" title="Switch View Mode">
-        🛠 <span id="currentLayoutMode">wide</span>
-      </a>
-      <div class="theme-toggle-group" id="themeToggleGroup">
-        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
-        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
-        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
-      </div>
-      <div class="dropdown ms-2">
-        <a class="btn btn-light nav-icon-btn dropdown-toggle" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">
-          <span>⚙️</span>
+    <div class="title-bar-actions d-flex align-items-center gap-3">
+      <div class="config-bar d-flex align-items-center gap-2">
+        <a id="layoutModeToggle" class="btn btn-outline-primary nav-icon-btn layout-toggle-btn" href="#" role="button" title="Switch View Mode">
+          🛠 <span id="currentLayoutMode">wide</span>
         </a>
-      <ul class="dropdown-menu" aria-labelledby="settingsDropdown">
-        <li><a class="dropdown-item" href="/system/themes/editor"><span>🎨</span> Theme Builder</a></li>
-        <li><a class="dropdown-item" href="/system/database_viewer"><span>🗃️</span> Database Viewer</a></li>
-        <li><a class="dropdown-item" href="/system/alert_thresholds"><span>📏</span> Alert Thresholds</a></li>
-        <li><a class="dropdown-item" href="/system/xcom_config"><span>🔌</span> XCom Config</a></li>
-      </ul>
+        <div class="theme-toggle-group" id="themeToggleGroup">
+          <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
+          <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
+          <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
+        </div>
+        <div class="dropdown ms-2">
+          <a class="btn btn-light nav-icon-btn dropdown-toggle" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">
+            <span>⚙️</span>
+          </a>
+        <ul class="dropdown-menu" aria-labelledby="settingsDropdown">
+          <li><a class="dropdown-item" href="/system/themes/editor"><span>🎨</span> Theme Builder</a></li>
+          <li><a class="dropdown-item" href="/system/database_viewer"><span>🗃️</span> Database Viewer</a></li>
+          <li><a class="dropdown-item" href="/system/alert_thresholds"><span>📏</span> Alert Thresholds</a></li>
+          <li><a class="dropdown-item" href="/system/xcom_config"><span>🔌</span> XCom Config</a></li>
+        </ul>
+      </div>
+      </div>
+      <div class="cyclone-bar d-flex align-items-center gap-2 ms-3">
+        <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="sync"   title="Jupiter Sync"><span>🪐</span></a>
+        <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="market" title="Market Update"><span>💲</span></a>
+        <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="full"  title="Full Cycle"><span>🌪️</span></a>
+        <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="wipe"  title="Wipe All"><span>🗑️</span></a>
+      </div>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- place theme and settings buttons in a separate container
- only style Jupiter/price/full/wipe buttons with the cyclone bar

## Testing
- `pytest -q` *(fails: command not found)*