### PR TITLE
Add title bar to XCom settings page

### DIFF
--- a/templates/system/xcom_config.html
+++ b/templates/system/xcom_config.html
@@ -2,7 +2,12 @@
 
 {% block title %}XCom Settings{% endblock %}
 
+{% block head %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+{% endblock %}
+
 {% block content %}
+{% include "title_bar.html" %}
 <div class="container-fluid pt-4">
   <h2 class="mb-4"><i class="fas fa-plug text-primary me-2"></i>XCom Settings</h2>
 


### PR DESCRIPTION
## Summary
- ensure system templates folder exists
- include title bar on the XCom configuration page

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*