### PR TITLE
Fix missing CalcServices import

### DIFF
--- a/app/positions_bp.py
+++ b/app/positions_bp.py
@@ -11,6 +11,7 @@ from flask import (
 from core.logging import log
 from positions.position_core import PositionCore
 from calc_core.calculation_core import CalculationCore
+from calc_core.calc_services import CalcServices
 from utils.route_decorators import route_log_alert
 from config.config_loader import load_config
 from core.constants import ALERT_LIMITS_PATH


### PR DESCRIPTION
## Summary
- ensure `CalcServices` is imported in `positions_bp`

## Testing
- `pytest -q` *(fails: command not found)*