### PR TITLE
Fix status card text color across themes

### DIFF
--- a/static/css/sonic_themes.css
+++ b/static/css/sonic_themes.css
@@ -92,6 +92,11 @@ body {
   transition: background 0.4s ease, color 0.4s ease;
 }
 
+/* Force a consistent text color for status cards */
+.status-card {
+  color: #222 !important;
+}
+
 .navbar,
 .title-bar {
   background: var(--title-bar-bg);


### PR DESCRIPTION
## Summary
- keep portfolio status and monitor card text dark for all themes

## Testing
- `pytest -q` *(fails: command not found)*