### PR TITLE
Add per-theme panel border controls

### DIFF
--- a/static/css/sonic_themes.css
+++ b/static/css/sonic_themes.css
@@ -1,7 +1,8 @@
 /* ===========================================================
    Super Theme Adjustments
-   This section defines color variables for each theme.
-   Modify these values to customize the look and feel.
+   This section defines appearance variables for each theme.
+   Modify these values to customize the look and feel, including
+   panel border colors and widths.
    =========================================================== */
 
 :root {
@@ -10,6 +11,8 @@
   --text: #222;
   --card-bg: #f8fafc;
   --card-border: #b7c5e0;
+  --panel-border: #b7c5e0;
+  --panel-border-width: 1.5px;
   --navbar: #8fbbef;
   --title-bar-bg: #8fbbef;
   --panel-title: #fff;
@@ -26,6 +29,8 @@
   --text: #222;
   --card-bg: #f8fafc;
   --card-border: #b7c5e0;
+  --panel-border: #b7c5e0;
+  --panel-border-width: 1.5px;
   --navbar: #8fbbef;
   --title-bar-bg: #8fbbef;
   --panel-title: #2e4372;
@@ -41,6 +46,8 @@
   --text: #eee;
   --card-bg: #23272f;
   --card-border: #39404e;
+  --panel-border: #39404e;
+  --panel-border-width: 1.5px;
   --navbar: #191c22;
   --title-bar-bg: #191c22;
   --panel-title: #fff;
@@ -56,6 +63,8 @@
   --text: #ffec99;
   --card-bg: #3a2f5d;
   --card-border: #e5eff3;
+  --panel-border: #e5eff3;
+  --panel-border-width: 2px;
   --navbar: #8db5e1;
   --title-bar-bg: #8db5e1;
   --panel-title: #ffec99;
@@ -139,6 +148,7 @@ body {
 .sonic-content-panel {
   background: var(--card-bg) !important;
   color: var(--text) !important;
+  border: var(--panel-border-width) solid var(--panel-border);
   transition: background 0.25s, color 0.25s;
 }
 :root[data-theme="funky"] {
@@ -146,6 +156,8 @@ body {
   --text: #ffec99;
   --card-bg: #3a2f5d;
   --card-border: #e5eff3;
+  --panel-border: #e5eff3;
+  --panel-border-width: 2px;
   --navbar: #8db5e1;
   --title-bar-bg: #8db5e1;
   --panel-title: #ffec99;
@@ -224,6 +236,7 @@ body {
 .sonic-content-panel {
   background: var(--card-bg) !important;
   color: var(--text) !important;
+  border: var(--panel-border-width) solid var(--panel-border);
   transition: background 0.25s, color 0.25s;
 }
 .sonic-section-container {


### PR DESCRIPTION
## Summary
- support `--panel-border` and `--panel-border-width` CSS variables
- apply these variables to `.sonic-content-panel`

## Testing
- `pytest -q` *(fails: command not found)*