### PR TITLE
Add Twilio run script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for Twilio scripts
+# Copy this file to `.env` and fill in your credentials.
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your_auth_token
+# Optional parameters for triggering a Studio Flow
+TWILIO_FLOW_SID=FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_FROM_PHONE=+15555555555
+TWILIO_TO_PHONE=+15555555555

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # v0.8
+
+## Twilio Testing
+
+To verify your Twilio credentials or trigger a Studio Flow, copy `.env.example` to
+`.env` and fill in your details. Then run:
+
+```bash
+python scripts/twilio_run.py
+```
+
+The script loads credentials from the `.env` file (or environment variables) and
+uses `scripts/twilio_test.py` to perform the authentication and optional flow
+execution.

--- a/scripts/twilio_run.py
+++ b/scripts/twilio_run.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run Twilio authentication and optional flow using environment variables.
+
+This script loads credentials and flow parameters from environment variables or
+an optional `.env` file at the repository root. It then delegates to
+`scripts.twilio_test` to perform authentication and optionally trigger a
+Twilio Studio Flow.
+
+Expected environment variables:
+    TWILIO_ACCOUNT_SID   - Twilio Account SID
+    TWILIO_AUTH_TOKEN    - Twilio Auth Token
+    TWILIO_FLOW_SID      - (optional) Studio Flow SID
+    TWILIO_FROM_PHONE    - (optional) From phone number
+    TWILIO_TO_PHONE      - (optional) To phone number
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Make sure we can import scripts.twilio_test when executed from repo root
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from twilio_test import main as twilio_test_main
+
+
+def build_argv() -> list[str]:
+    """Construct argument list for ``twilio_test.main`` from environment."""
+    argv: list[str] = []
+    sid = os.getenv("TWILIO_ACCOUNT_SID")
+    token = os.getenv("TWILIO_AUTH_TOKEN")
+    flow_sid = os.getenv("TWILIO_FLOW_SID")
+    from_phone = os.getenv("TWILIO_FROM_PHONE")
+    to_phone = os.getenv("TWILIO_TO_PHONE")
+
+    if sid:
+        argv += ["--sid", sid]
+    if token:
+        argv += ["--token", token]
+    if flow_sid:
+        argv += ["--flow-sid", flow_sid]
+    if from_phone:
+        argv += ["--from-phone", from_phone]
+    if to_phone:
+        argv += ["--to-phone", to_phone]
+    return argv
+
+
+def main() -> int:
+    env_file = Path(__file__).resolve().parent.parent / ".env"
+    if env_file.exists():
+        load_dotenv(env_file)
+    argv = build_argv()
+    return twilio_test_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- provide a template `.env.example` for Twilio credentials
- add `twilio_run.py` to run `twilio_test` using env vars
- update README with instructions

## Testing
- `pytest -q` *(fails: command not found)*