### PR TITLE
Adjust cyclone button styles

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -79,13 +79,15 @@
   background: #cce5ff;
   border-radius: 50px;
   box-shadow: inset 0 0 5px #ffa726;
-  padding: 0.75rem 1.25rem;
+  padding: 0.45rem 1.25rem;
   width: fit-content;
   margin: auto;
   gap: 1rem;
 }
 .cyclone-btn {
-  font-size: 1.5rem;
+  font-size: 2rem;
+  min-width: 48px;
+  min-height: 48px;
   padding: 0.4rem 0.6rem;
   border: none;
   border-radius: 50%;


### PR DESCRIPTION
## Summary
- shorten the cyclone pill bar height
- enlarge cyclone icons

## Testing
- `pytest -k "this_test_does_not_exist" -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*