### PR TITLE
Remove unused fuzzy_match_key import

### DIFF
--- a/utils/console_logger.py
+++ b/utils/console_logger.py
@@ -2,7 +2,6 @@ import json
 import time
 import inspect
 from datetime import datetime
-from utils.fuzzy_wuzzy import fuzzy_match_key
 
 
 class ConsoleLogger:


### PR DESCRIPTION
## Summary
- clean up unused `fuzzy_match_key` import in `utils/console_logger`

## Testing
- `ruff check utils/console_logger.py`
- `python -m py_compile utils/console_logger.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts', etc.)*