### PR TITLE
Ensure logging configured before DataLocker

### DIFF
--- a/cyclone/cyclone_console/commands/alerts.py
+++ b/cyclone/cyclone_console/commands/alerts.py
@@ -4,12 +4,13 @@ import typer
 from rich.table import Table
 from rich.console import Console
 from cyclone.cyclone_alert_service import CycloneAlertService
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
-from core.constants import DB_PATH
 
 app = typer.Typer(help="🔔 Alert tools: view, enrich, evaluate")
 
 console = Console()
+configure_console_log()
 dl = DataLocker(str(DB_PATH))
 service = CycloneAlertService(dl)
 

--- a/cyclone/cyclone_console/commands/hedge.py
+++ b/cyclone/cyclone_console/commands/hedge.py
@@ -3,7 +3,7 @@
 import typer
 from rich.console import Console
 from rich.table import Table
-from core.constants import DB_PATH
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
 from sonic_labs.hedge_manager import HedgeManager
 from cyclone.cyclone_hedge_service import CycloneHedgeService
@@ -11,6 +11,7 @@ from cyclone.cyclone_hedge_service import CycloneHedgeService
 app = typer.Typer(help="🛡 Hedge detection and management")
 
 console = Console()
+configure_console_log()
 dl = DataLocker(str(DB_PATH))
 service = CycloneHedgeService(dl)
 

--- a/cyclone/cyclone_console/commands/portfolio.py
+++ b/cyclone/cyclone_console/commands/portfolio.py
@@ -5,12 +5,13 @@ from rich.console import Console
 from rich.table import Table
 from cyclone.cyclone_portfolio_service import CyclonePortfolioService
 from positions.position_core_service import PositionCoreService
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
-from core.constants import DB_PATH
 
 app = typer.Typer(help="📦 Portfolio tools")
 
 console = Console()
+configure_console_log()
 dl = DataLocker(str(DB_PATH))
 portfolio_service = CyclonePortfolioService(dl)
 core_service = PositionCoreService(dl)

--- a/cyclone/cyclone_console/commands/positions.py
+++ b/cyclone/cyclone_console/commands/positions.py
@@ -3,14 +3,15 @@
 import typer
 from rich.table import Table
 from rich.console import Console
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
-from core.constants import DB_PATH
 from cyclone.cyclone_position_service import CyclonePositionService
 from core.logging import log
 
 app = typer.Typer(help="📊 Position lifecycle commands")
 
 console = Console()
+configure_console_log()
 dl = DataLocker(str(DB_PATH))
 service = CyclonePositionService(dl)
 

--- a/cyclone/cyclone_console/commands/prices.py
+++ b/cyclone/cyclone_console/commands/prices.py
@@ -6,13 +6,14 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import typer
 from rich.table import Table
 from rich.console import Console
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
 from monitor.price_monitor import PriceMonitor
-from core.constants import DB_PATH
 
 app = typer.Typer(help="💰 Market price operations")
 
 console = Console()
+configure_console_log()
 dl = DataLocker(str(DB_PATH))
 
 

--- a/cyclone/cyclone_console/commands/system.py
+++ b/cyclone/cyclone_console/commands/system.py
@@ -3,12 +3,13 @@
 import typer
 from rich.console import Console
 from cyclone.cyclone_engine import Cyclone
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
-from core.constants import DB_PATH
 
 app = typer.Typer(help="🧹 System operations: wipe, reset, maintenance")
 
 console = Console()
+configure_console_log()
 cyclone = Cyclone()
 dl = DataLocker(str(DB_PATH))
 

--- a/cyclone/cyclone_console/utils/cli_renderer - Copy.py
+++ b/cyclone/cyclone_console/utils/cli_renderer - Copy.py
@@ -3,8 +3,8 @@
 import typer
 from rich.console import Console
 from cyclone_engine import Cyclone
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
-from core.constants import DB_PATH
 
 from cyclone_console.utils.cli_renderer import banner, print_success, print_warning, print_error
 from cyclone_console.utils.confirm_prompt import confirm_action
@@ -12,6 +12,7 @@ from cyclone_console.utils.confirm_prompt import confirm_action
 app = typer.Typer(help="🧹 System operations: wipe, reset, maintenance")
 
 console = Console()
+configure_console_log()
 cyclone = Cyclone()
 dl = DataLocker(str(DB_PATH))
 

--- a/cyclone_app.py
+++ b/cyclone_app.py
@@ -6,10 +6,11 @@ from rich.prompt import Prompt
 from rich.table import Table
 from cyclone.cyclone_engine import Cyclone
 from monitor.monitor_core import MonitorCore
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
-from core.constants import DB_PATH
 
 console = Console()
+configure_console_log()
 dl = DataLocker(str(DB_PATH))
 monitor_core = MonitorCore()
 cyclone = Cyclone(monitor_core)

--- a/data/insert_wallets.py
+++ b/data/insert_wallets.py
@@ -4,7 +4,7 @@ import sqlite3
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from core.core_imports import DB_PATH
+from core.core_imports import DB_PATH, configure_console_log
 from data.data_locker import DataLocker
 
 def ensure_wallets_table(db):
@@ -25,6 +25,7 @@ def ensure_wallets_table(db):
     print("✅ Wallets table is ready.")
 
 # ✅ Initialize connection
+configure_console_log()
 dl = DataLocker(str(DB_PATH))
 ensure_wallets_table(dl.db)
 

--- a/data/threshold_seeder.py
+++ b/data/threshold_seeder.py
@@ -65,7 +65,9 @@ class AlertThresholdSeeder:
 # 🧠 Standalone Runner
 if __name__ == "__main__":
     try:
+        from core.core_imports import configure_console_log
         from data.data_locker import DataLocker
+        configure_console_log()
         print(f"🧪 Connecting to DB: {DB_PATH}")
         dl = DataLocker(DB_PATH)
         seeder = AlertThresholdSeeder(dl.db)

--- a/monitor/monitor_console.py
+++ b/monitor/monitor_console.py
@@ -16,10 +16,12 @@ from operations_monitor import OperationsMonitor
 from latency_monitor import LatencyMonitor
 from position_monitor import PositionMonitor
 from utils.console_logger import ConsoleLogger as log
+from core.core_imports import configure_console_log
 from data.data_locker import DataLocker
 
 # ✅ Resolve correct DB path
 DB_PATH = os.getenv("DB_PATH", os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data", "mother_brain.db")))
+configure_console_log()
 data_locker = DataLocker(DB_PATH)
 ledger = data_locker.ledger
 

--- a/monitor/operations_monitor.py
+++ b/monitor/operations_monitor.py
@@ -73,7 +73,9 @@ class OperationsMonitor(BaseMonitor):
         return {"post_success": success, "duration_seconds": duration}
 
 if __name__ == "__main__":
+    from core.core_imports import configure_console_log
     log.banner("🚀 SELF-RUN: OperationsMonitor")
+    configure_console_log()
 
     monitor = OperationsMonitor()
     result = monitor._do_work()

--- a/operations_console.py
+++ b/operations_console.py
@@ -4,6 +4,7 @@ import sys, os
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 from utils.console_logger import ConsoleLogger as log
+from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
 from xcom.xcom_core import XComCore
 from monitor.monitor_core import MonitorCore
@@ -11,8 +12,8 @@ from monitor.monitor_registry import MonitorRegistry
 from monitor.price_monitor import PriceMonitor
 from data.dl_system_data import DLSystemDataManager
 
-from core.constants import DB_PATH
-from data.data_locker import DataLocker
+
+configure_console_log()
 
 dl = DataLocker(str(DB_PATH))  # Same DB as Sonic Dashboard
 xcom = XComCore(dl.system)

--- a/sonic_app.py
+++ b/sonic_app.py
@@ -19,6 +19,11 @@ from system.system_core import SystemCore
 from monitor.monitor_core import MonitorCore
 from cyclone.cyclone_engine import Cyclone
 
+# --- Logging Setup ---
+log.banner("SONIC DASHBOARD STARTUP")
+log.enable_all()
+configure_console_log()
+
 # --- Flask Setup ---
 app = Flask(__name__)
 app.debug = False
@@ -30,12 +35,6 @@ app.data_locker = DataLocker(str(DB_PATH))
 app.system_core = SystemCore(app.data_locker)
 app.monitor_core = MonitorCore()
 app.cyclone = Cyclone(monitor_core=app.monitor_core)
-
-# --- Logging Setup ---
-log.banner("SONIC DASHBOARD STARTUP")
-log.enable_all()
-log.init_status()
-configure_console_log()
 
 # --- Blueprints ---
 from app.positions_bp import positions_bp


### PR DESCRIPTION
## Summary
- set up console logging ahead of DataLocker initialization in `sonic_app.py`
- configure logging early in `operations_console.py` and related scripts
- silence DataLocker logs for CLI command modules and helper scripts

## Testing
- `pytest -q` *(fails: ImportError while importing tests)*