### PR TITLE
Fix icon size inconsistencies

### DIFF
--- a/app/alert_monitor/alert_monitor.css
+++ b/app/alert_monitor/alert_monitor.css
@@ -87,8 +87,6 @@ h2 {
   box-shadow: none;
 }
 .asset-icon {
-  width: 34px;
-  height: 34px;
   border-radius: 50%;
   object-fit: cover;
   border: 1px solid #ccc;

--- a/app/positions/positions_table.html
+++ b/app/positions/positions_table.html
@@ -39,8 +39,6 @@
     cursor: pointer;
   }
   .asset-icon {
-    width: 32px;
-    height: 32px;
     border-radius: 50%;
     object-fit: cover;
   }

--- a/static/css/alert_matrix.css
+++ b/static/css/alert_matrix.css
@@ -1,6 +1,4 @@
 .asset-icon {
-  width: 34px;
-  height: 34px;
   border-radius: 50%;
   object-fit: cover;
 }

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -1,0 +1,8 @@
+.asset-icon,
+.wallet-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+

--- a/static/css/liquidation_bars.css
+++ b/static/css/liquidation_bars.css
@@ -144,8 +144,6 @@
 }
 
 .wallet-icon {
-  width: 32px;
-  height: 32px;
   object-fit: cover;
   border-radius: 50%;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
   {% block head %}{% endblock %}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/icons.css') }}">
   {% block extra_styles %}{% endblock %}
 </head>
 <body>

--- a/templates/positions_table.html
+++ b/templates/positions_table.html
@@ -107,8 +107,8 @@
 .positions-table tfoot th.left { text-align: left; }
 
 .asset-icon {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
   object-fit: cover;
   display: inline-block;


### PR DESCRIPTION
## Summary
- add shared `icons.css` with standard icon sizes
- link new stylesheet from `base.html`
- remove size rules from various pages and align to 32px

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*