### PR TITLE
Refactor alert status section layout

### DIFF
--- a/static/css/alert_status.css
+++ b/static/css/alert_status.css
@@ -1,15 +1,4 @@
-.alert-status-flex {
-  display: flex;
-  gap: 2rem;
+.alert-table,
+.alert-bars {
   width: 100%;
-  justify-content: center;
-  align-items: flex-start;
-  flex-wrap: wrap;
-}
-
-.alert-status-flex .alert-table,
-.alert-status-flex .alert-bars {
-  flex: 1 1 320px;
-  min-width: 260px;
-  max-width: 100%;
 }

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -16,7 +16,6 @@
 {% include "title_bar.html" %}
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel">
-    <div class="alert-status-flex">
       <div class="alert-table">
         <div class="section-title">Alerts</div>
         <div class="positions-table-wrapper">
@@ -50,6 +49,8 @@
       </table>
         </div>
       </div>
+  </div>
+  <div class="sonic-content-panel">
       <div class="alert-bars">
         <div class="section-title">Proximity to Alert</div>
         <div id="alertBars">
@@ -84,7 +85,6 @@
       {% endif %}
         </div>
       </div>
-    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- restructure alert status page so the table and bars are each in their own `sonic-content-panel`
- simplify alert status CSS

## Testing
- `pytest -q` *(fails: 42 errors during collection)*