### PR TITLE
Add refresh timer dial to title bar

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -102,3 +102,38 @@
   box-shadow: none;
   transform: scale(1.15);
 }
+
+/* Refresh Dial */
+.refresh-dial {
+  position: relative;
+  width: 36px;
+  height: 36px;
+}
+.refresh-dial svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+.refresh-dial circle {
+  fill: none;
+  stroke-width: 3;
+}
+.refresh-dial circle.bg {
+  stroke: #ddd;
+}
+.refresh-dial circle.progress {
+  stroke: #7c3aed;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.5s linear;
+}
+.refresh-dial .timer-number {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 0.65rem;
+  font-weight: 600;
+}

--- a/static/js/refresh_timer.js
+++ b/static/js/refresh_timer.js
@@ -1,0 +1,35 @@
+console.log('✅ refresh_timer.js loaded');
+
+document.addEventListener('DOMContentLoaded', () => {
+  const INTERVAL = 60; // seconds
+  let remaining = INTERVAL;
+  const dial = document.getElementById('refreshDial');
+  if (!dial) return;
+
+  const progress = dial.querySelector('circle.progress');
+  const number = dial.querySelector('.timer-number');
+  if (!progress) return;
+
+  const radius = progress.r.baseVal.value;
+  const circumference = 2 * Math.PI * radius;
+
+  progress.style.strokeDasharray = `${circumference}`;
+  progress.style.strokeDashoffset = `${circumference}`;
+
+  function updateDial() {
+    const offset = circumference * (1 - remaining / INTERVAL);
+    progress.style.strokeDashoffset = offset;
+    if (number) number.textContent = remaining;
+  }
+
+  updateDial();
+
+  setInterval(() => {
+    remaining -= 1;
+    if (remaining <= 0) {
+      window.location.reload();
+    } else {
+      updateDial();
+    }
+  }, 1000);
+});

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -9,6 +9,13 @@
     <a class="btn btn-light nav-icon-btn" href="/system/xcom_config" title="XCom Config"><span>🔌</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
+    <div id="refreshDial" class="refresh-dial" title="UI auto-refresh">
+      <svg viewBox="0 0 36 36">
+        <circle class="bg" cx="18" cy="18" r="16" />
+        <circle class="progress" cx="18" cy="18" r="16" />
+      </svg>
+      <span class="timer-number"></span>
+    </div>
   </div>
     <div class="title-bar-actions d-flex align-items-center gap-3">
       <div class="config-bar d-flex align-items-center gap-2">
@@ -40,4 +47,5 @@
       </div>
     </div>
   </div>
-</nav>
+  </nav>
+  <script src="{{ url_for('static', filename='js/refresh_timer.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- show a countdown dial in the title bar
- style the refresh dial
- auto-refresh the page every minute

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*