### PR TITLE
Fix card back colors

### DIFF
--- a/templates/monitor_cards.html
+++ b/templates/monitor_cards.html
@@ -12,7 +12,7 @@
               </div>
               <div class="led-dot {{ item.color }}"></div>
             </div>
-          <div class="flip-card-back">
+          <div class="flip-card-back status-card monitor-style {{ item.color }}">
             {% if item.title == "Price" %}
               <strong>Status:</strong>
               {% if item.color == 'green' %}✅{% elif item.color == 'yellow' %}⚠️{% else %}❌{% endif %}

--- a/templates/portfolio_cards.html
+++ b/templates/portfolio_cards.html
@@ -8,7 +8,7 @@
             <div class="icon">{{ item.icon }}</div>
             <div class="value">{{ item.value }}</div>
           </div>
-          <div class="flip-card-back">
+          <div class="flip-card-back status-card {{ item.color }}">
             {% set thresholds = portfolio_limits.get(item.title.lower().replace(' ', '_'), {}) %}
             <div class="thresholds">
               <div><span class="dot green"></span> Low: {{ thresholds.low }}</div>


### PR DESCRIPTION
## Summary
- make portfolio card backs use the same color class as the front
- make monitor card backs use the same color class as the front

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*