### PR TITLE
Fix portfolio limits on dashboard cards

### DIFF
--- a/templates/portfolio_cards.html
+++ b/templates/portfolio_cards.html
@@ -1,5 +1,12 @@
 <div class="section-title">Portfolio</div>
 <div class="card-flex">
+    {% set title_to_key = {
+        'value': 'total_value',
+        'leverage': 'avg_leverage',
+        'size': 'total_size',
+        'ratio': 'value_to_collateral_ratio',
+        'travel': 'avg_travel_percent'
+    } %}
     {% for item in status_items %}
       <div class="flip-card">
         <div class="flip-card-inner">
@@ -9,7 +16,8 @@
             <div class="value">{{ item.value }}</div>
           </div>
           <div class="flip-card-back status-card {{ item.color }}">
-            {% set thresholds = portfolio_limits.get(item.title.lower().replace(' ', '_'), {}) %}
+            {% set key = title_to_key.get(item.title.lower(), item.title.lower().replace(' ', '_')) %}
+            {% set thresholds = portfolio_limits.get(key, {}) %}
             <div class="thresholds">
               <div><span class="dot green"></span> Low: {{ thresholds.low }}</div>
               <div><span class="dot yellow"></span> Med: {{ thresholds.medium }}</div>


### PR DESCRIPTION
## Summary
- display portfolio limit thresholds when portfolio cards are flipped

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*