### PR TITLE
Move hedge modifiers to DB with API

### DIFF
--- a/static/js/hedge_calculator.js
+++ b/static/js/hedge_calculator.js
@@ -110,7 +110,33 @@ function sliderChanged(){
   updateProjectedHeatIndex();
 }
 
-document.getElementById('saveModifiers').addEventListener('click',()=>alert('Save modifiers called')); 
+document.getElementById('saveModifiers').addEventListener('click', async () => {
+  const hedge = {
+    feePercentage: parseFloat(document.getElementById('feePercentage').value) || 0,
+    targetMargin: parseFloat(document.getElementById('targetMarginInput').value) || 0,
+    adjustmentFactor: parseFloat(document.getElementById('adjustmentFactorInput').value) || 0
+  };
+  const heat = {
+    distanceWeight: parseFloat(document.getElementById('distanceWeightInput').value) || 0,
+    leverageWeight: parseFloat(document.getElementById('leverageWeightInput').value) || 0,
+    collateralWeight: parseFloat(document.getElementById('collateralWeightInput').value) || 0
+  };
+  try {
+    await fetch('/system/modifiers/hedge_modifiers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(hedge)
+    });
+    await fetch('/system/modifiers/heat_modifiers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(heat)
+    });
+    alert('Modifiers saved');
+  } catch (err) {
+    alert('Failed to save modifiers');
+  }
+});
 
 function updateProjectedHeatIndex(){
   const lev = parseFloat(document.getElementById('leverageSlider').value);


### PR DESCRIPTION
## Summary
- seed modifiers from `sonic_sauce.json` when database is empty
- expose `/system/modifiers/<group>` REST endpoints
- update hedge calculator page and sonic labs blueprint to use DB modifiers only
- save modifier values from the Hedge Calculator UI

## Testing
- `pytest -q` *(fails: 42 errors during collection)*