### PR TITLE
Fix alert status layout mode

### DIFF
--- a/static/js/layout_mode.js
+++ b/static/js/layout_mode.js
@@ -1,0 +1,22 @@
+// Layout mode toggle script
+console.log('layout_mode.js loaded');
+const LAYOUT_MODES = ['wide-mode', 'fitted-mode', 'mobile-mode'];
+let layoutCurrent = 0;
+function setLayoutMode(idx) {
+  document.body.classList.remove(...LAYOUT_MODES);
+  document.body.classList.add(LAYOUT_MODES[idx]);
+  const label = document.getElementById('currentLayoutMode');
+  if (label) label.innerText = LAYOUT_MODES[idx].replace('-mode', '');
+  localStorage.setItem('sonicLayoutMode', idx);
+}
+document.addEventListener('DOMContentLoaded', function() {
+  const btn = document.getElementById('layoutModeToggle');
+  layoutCurrent = Number(localStorage.getItem('sonicLayoutMode')) || 0;
+  setLayoutMode(layoutCurrent);
+  if (btn) {
+    btn.addEventListener('click', function() {
+      layoutCurrent = (layoutCurrent + 1) % LAYOUT_MODES.length;
+      setLayoutMode(layoutCurrent);
+    });
+  }
+});

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -146,4 +146,5 @@ document.addEventListener("DOMContentLoaded", function() {
   sortTable(currentSort.col, currentSort.dir);
 });
 </script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
 {% endblock %}

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -18,28 +18,7 @@
   {% include "dash_bottom.html" %}
 
   <!-- JS: Layout Mode Toggle -->
-  <script>
-    const MODES = ['wide-mode', 'fitted-mode', 'mobile-mode'];
-    let current = 0;
-    function setLayoutMode(idx) {
-      document.body.classList.remove(...MODES);
-      document.body.classList.add(MODES[idx]);
-      const label = document.getElementById('currentLayoutMode');
-      if (label) label.innerText = MODES[idx].replace('-mode', '');
-      localStorage.setItem('sonicLayoutMode', idx);
-    }
-    document.addEventListener('DOMContentLoaded', function () {
-      const btn = document.getElementById('layoutModeToggle');
-      current = Number(localStorage.getItem('sonicLayoutMode')) || 0;
-      setLayoutMode(current);
-      if (btn) {
-        btn.addEventListener('click', function () {
-          current = (current + 1) % MODES.length;
-          setLayoutMode(current);
-        });
-      }
-    });
-  </script>
+  <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
   <!-- JS: Theme Toggle -->
   <script>
     const THEME_KEY = "themeMode";


### PR DESCRIPTION
## Summary
- implement layout mode toggle globally
- use layout script on alert status page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*