### PR TITLE
Redesign alert limits page

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -1,28 +1,28 @@
 {% extends "base.html" %}
 
 {% block head %}
-<script src="{{ url_for('static', filename='js/api_routes.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/api_routes.js') }}"></script>
 {% endblock %}
 
 {% block title %}Alert Limits Configuration{% endblock %}
 
 {% block extra_styles %}
-{{ super() }}
-<style>
-  .save-spinner {
-    display: none;
-    width: 1.5rem;
-    height: 1.5rem;
-    border: 2px solid #f3f3f3;
-    border-top: 2px solid #3498db;
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-  }
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-  }
-</style>
+  {{ super() }}
+  <style>
+    .save-spinner {
+      display: none;
+      width: 1.5rem;
+      height: 1.5rem;
+      border: 2px solid #f3f3f3;
+      border-top: 2px solid #3498db;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+  </style>
 {% endblock %}
 
 {% block content %}
@@ -30,131 +30,62 @@
   <h1 class="mb-4">Alert Limits</h1>
   <p>This page will hold alert configuration options.</p>
 
-<form id="alertForm" method="POST" action="{{ url_for('alerts_bp.update_config') }}">
+  <form id="alertForm" method="POST" action="{{ url_for('alerts_bp.update_config') }}">
 
+    <ul class="nav nav-tabs" id="alertTabNav" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="all-tab" data-bs-toggle="tab" data-bs-target="#all" type="button" role="tab">All</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="price-tab" data-bs-toggle="tab" data-bs-target="#price" type="button" role="tab">Price Alerts</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="global-tab" data-bs-toggle="tab" data-bs-target="#global" type="button" role="tab">Global Alerts</button>
+      </li>
+    </ul>
 
-<!-- 📈 Price Alerts -->
-<div class="card mb-4">
-  <div class="card-header bg-primary text-white">
-    <i class="fas fa-dollar-sign me-2"></i>Price Alerts
-  </div>
-        <div class="card-body">
-    <div class="row">
-      {% for asset in ["BTC", "ETH", "SOL"] %}
-      {% set asset_conf = price_alerts.get(asset, {}) %}
-      <div class="col-md-4 mb-4">
-        <div class="card h-100 text-center shadow-sm">
-          <div class="card-body">
-            {% if asset == "BTC" %}
-              <img src="https://cryptologos.cc/logos/bitcoin-btc-logo.svg?v=023" style="width:40px;">
-            {% elif asset == "ETH" %}
-              <img src="https://cryptologos.cc/logos/ethereum-eth-logo.svg?v=023" style="width:40px;">
-            {% elif asset == "SOL" %}
-              <img src="https://cryptologos.cc/logos/solana-sol-logo.svg?v=023" style="width:40px;">
-{% endif %}
-            <h4 class="mt-2">{{ asset }}</h4>
-
-            <label class="form-label mt-3">Trigger Value:</label>
-            <input type="number" step="0.01" class="form-control"
-                   name="alert_ranges[price_alerts][{{ asset }}][trigger_value]"
-                   value="{{ asset_conf.get('trigger_value', '') }}">
-
-            <label class="form-label mt-3">Condition:</label>
-            <select class="form-select" name="alert_ranges[price_alerts][{{ asset }}][condition]">
-              <option value="ABOVE" {% if asset_conf.get('condition') == 'ABOVE' %}selected{% endif %}>Above</option>
-              <option value="BELOW" {% if asset_conf.get('condition') == 'BELOW' %}selected{% endif %}>Below</option>
-            </select>
-
-            <div class="form-check form-switch mt-3">
-              <input type="hidden" name="alert_ranges[price_alerts][{{ asset }}][enabled]" value="false">
-              <input type="checkbox" class="form-check-input"
-                     name="alert_ranges[price_alerts][{{ asset }}][enabled]" value="true"
-                     {% if asset_conf.get('enabled') %}checked{% endif %}>
-              <label class="form-check-label">Enabled</label>
+    <div class="tab-content pt-3" id="alertTabContent">
+      <!-- All Tab -->
+      <div class="tab-pane fade show active" id="all" role="tabpanel">
+        <div class="accordion" id="alertLimitsAccordion">
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="headingPrice">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePrice" aria-expanded="false" aria-controls="collapsePrice">
+                <i class="fas fa-dollar-sign me-2"></i>Price Alerts
+              </button>
+            </h2>
+            <div id="collapsePrice" class="accordion-collapse collapse" aria-labelledby="headingPrice" data-bs-parent="#alertLimitsAccordion">
+              <div class="accordion-body">
+                {% include "partials/price_alerts_section.html" %}
+              </div>
             </div>
-
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="headingGlobal">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseGlobal" aria-expanded="false" aria-controls="collapseGlobal">
+                <i class="fas fa-globe me-2"></i>Global Alerts
+              </button>
+            </h2>
+            <div id="collapseGlobal" class="accordion-collapse collapse" aria-labelledby="headingGlobal" data-bs-parent="#alertLimitsAccordion">
+              <div class="accordion-body">
+                {% include "partials/global_alerts_section.html" %}
+              </div>
+            </div>
           </div>
         </div>
       </div>
-{% endfor %}
-    </div>
-  </div>
-</div>
 
-<!-- 🌐 Global Alerts -->
-<div class="card mb-4">
-  <div class="card-header bg-info text-white">
-    <i class="fas fa-globe me-2"></i>Global Alerts
-  </div>
-  <div class="card-body">
-    <div class="form-check form-switch mb-4">
-      <input type="hidden" name="global_alert_config[enabled]" value="false">
-      <input type="checkbox" class="form-check-input"
-             name="global_alert_config[enabled]" value="true"
-             {% if global_alert_config.get('enabled') %}checked{% endif %}>
-      <label class="form-check-label">Enable Global Alerts</label>
-    </div>
+      <!-- Price Tab -->
+      <div class="tab-pane fade" id="price" role="tabpanel" aria-labelledby="price-tab">
+        {% include "partials/price_alerts_section.html" %}
+      </div>
 
-    <div class="row mb-4">
-      <div class="col-12">
-        <label class="form-label">Monitor Fields:</label>
-        <div class="d-flex flex-wrap gap-3">
-          {% for field in ["price", "profit", "travel_percent", "heat_index"] %}
-          <div class="form-check">
-            <input type="hidden" name="global_alert_config[data_fields][{{ field }}]" value="false">
-            <input type="checkbox" class="form-check-input"
-                   name="global_alert_config[data_fields][{{ field }}]" value="true"
-                   {% if global_alert_config.get('data_fields', {}).get(field) %}checked{% endif %}>
-            <label class="form-check-label text-capitalize">{{ field.replace('_',' ') }}</label>
-          </div>
-{% endfor %}
-        </div>
+      <!-- Global Tab -->
+      <div class="tab-pane fade" id="global" role="tabpanel" aria-labelledby="global-tab">
+        {% include "partials/global_alerts_section.html" %}
       </div>
     </div>
 
-    <div class="row">
-      <div class="col-md-4">
-        <label class="form-label">Profit Threshold</label>
-        <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][profit]"
-               value="{{ global_alert_config.get('thresholds', {}).get('profit', '') }}">
-      </div>
-      <div class="col-md-4">
-        <label class="form-label">Travel Threshold</label>
-        <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][travel_percent]"
-               value="{{ global_alert_config.get('thresholds', {}).get('travel_percent', '') }}">
-      </div>
-      <div class="col-md-4">
-        <label class="form-label">Heat Index Threshold</label>
-        <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][heat_index]"
-               value="{{ global_alert_config.get('thresholds', {}).get('heat_index', '') }}">
-      </div>
-    </div>
-
-    <div class="row mt-4">
-      <div class="col-12">
-        <label class="form-label">Price Thresholds per Asset:</label>
-        <div class="row g-2">
-          {% for asset in ["BTC", "ETH", "SOL"] %}
-          {% set price_conf = global_alert_config.get('thresholds', {}).get('price', {}) %}
-          <div class="col-md-4">
-            <label class="form-label">{{ asset }}</label>
-            <input type="number" step="0.01" class="form-control"
-                   name="global_alert_config[thresholds][price][{{ asset }}]"
-                   value="{{ price_conf.get(asset, '') }}">
-          </div>
-{% endfor %}
-        </div>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-  <!-- (continues...) -->
-
-</div>
-</form>
+  </form>
 </div>
 {% endblock %}
-
-

--- a/templates/partials/global_alerts_section.html
+++ b/templates/partials/global_alerts_section.html
@@ -1,0 +1,57 @@
+<div class="card mb-4">
+  <div class="card-header bg-info text-white">
+    <i class="fas fa-globe me-2"></i>Global Alerts
+  </div>
+  <div class="card-body">
+    <div class="form-check form-switch mb-4">
+      <input type="hidden" name="global_alert_config[enabled]" value="false">
+      <input type="checkbox" class="form-check-input" name="global_alert_config[enabled]" value="true" {% if global_alert_config.get('enabled') %}checked{% endif %}>
+      <label class="form-check-label">Enable Global Alerts</label>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-12">
+        <label class="form-label">Monitor Fields:</label>
+        <div class="d-flex flex-wrap gap-3">
+          {% for field in ["price", "profit", "travel_percent", "heat_index"] %}
+          <div class="form-check">
+            <input type="hidden" name="global_alert_config[data_fields][{{ field }}]" value="false">
+            <input type="checkbox" class="form-check-input" name="global_alert_config[data_fields][{{ field }}]" value="true" {% if global_alert_config.get('data_fields', {}).get(field) %}checked{% endif %}>
+            <label class="form-check-label text-capitalize">{{ field.replace('_', ' ') }}</label>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-4">
+        <label class="form-label">Profit Threshold</label>
+        <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][profit]" value="{{ global_alert_config.get('thresholds', {}).get('profit', '') }}">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Travel Threshold</label>
+        <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][travel_percent]" value="{{ global_alert_config.get('thresholds', {}).get('travel_percent', '') }}">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Heat Index Threshold</label>
+        <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][heat_index]" value="{{ global_alert_config.get('thresholds', {}).get('heat_index', '') }}">
+      </div>
+    </div>
+
+    <div class="row mt-4">
+      <div class="col-12">
+        <label class="form-label">Price Thresholds per Asset:</label>
+        <div class="row g-2">
+          {% for asset in ["BTC", "ETH", "SOL"] %}
+          {% set price_conf = global_alert_config.get('thresholds', {}).get('price', {}) %}
+          <div class="col-md-4">
+            <label class="form-label">{{ asset }}</label>
+            <input type="number" step="0.01" class="form-control" name="global_alert_config[thresholds][price][{{ asset }}]" value="{{ price_conf.get(asset, '') }}">
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/partials/price_alerts_section.html
+++ b/templates/partials/price_alerts_section.html
@@ -1,0 +1,42 @@
+<div class="card mb-4">
+  <div class="card-header bg-primary text-white">
+    <i class="fas fa-dollar-sign me-2"></i>Price Alerts
+  </div>
+  <div class="card-body">
+    <div class="row">
+      {% for asset in ["BTC", "ETH", "SOL"] %}
+      {% set asset_conf = price_alerts.get(asset, {}) %}
+      <div class="col-md-4 mb-4">
+        <div class="card h-100 text-center shadow-sm">
+          <div class="card-body">
+            {% if asset == "BTC" %}
+              <img src="https://cryptologos.cc/logos/bitcoin-btc-logo.svg?v=023" style="width:40px;">
+            {% elif asset == "ETH" %}
+              <img src="https://cryptologos.cc/logos/ethereum-eth-logo.svg?v=023" style="width:40px;">
+            {% elif asset == "SOL" %}
+              <img src="https://cryptologos.cc/logos/solana-sol-logo.svg?v=023" style="width:40px;">
+            {% endif %}
+            <h4 class="mt-2">{{ asset }}</h4>
+
+            <label class="form-label mt-3">Trigger Value:</label>
+            <input type="number" step="0.01" class="form-control" name="alert_ranges[price_alerts][{{ asset }}][trigger_value]" value="{{ asset_conf.get('trigger_value', '') }}">
+
+            <label class="form-label mt-3">Condition:</label>
+            <select class="form-select" name="alert_ranges[price_alerts][{{ asset }}][condition]">
+              <option value="ABOVE" {% if asset_conf.get('condition') == 'ABOVE' %}selected{% endif %}>Above</option>
+              <option value="BELOW" {% if asset_conf.get('condition') == 'BELOW' %}selected{% endif %}>Below</option>
+            </select>
+
+            <div class="form-check form-switch mt-3">
+              <input type="hidden" name="alert_ranges[price_alerts][{{ asset }}][enabled]" value="false">
+              <input type="checkbox" class="form-check-input" name="alert_ranges[price_alerts][{{ asset }}][enabled]" value="true" {% if asset_conf.get('enabled') %}checked{% endif %}>
+              <label class="form-check-label">Enabled</label>
+            </div>
+
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- revamp alert limits view with tabs and collapsible sections
- split price and global alert forms into partial templates

## Testing
- `pytest -k alert_limits -q` *(fails: ModuleNotFoundError: No module named 'alerts')*