### PR TITLE
Rename Hedge Calculator template and attach slider events

### DIFF
--- a/static/js/hedge_calculator.js
+++ b/static/js/hedge_calculator.js
@@ -155,4 +155,12 @@ document.addEventListener('DOMContentLoaded', () => {
   if (shortSel && shortSel.value) {
     loadShortPosition();
   }
+  const priceSlider = document.getElementById('priceSlider');
+  if (priceSlider) {
+    priceSlider.addEventListener('input', sliderChanged);
+  }
+  const leverageSlider = document.getElementById('leverageSlider');
+  if (leverageSlider) {
+    leverageSlider.addEventListener('input', updateProjectedHeatIndex);
+  }
 });

--- a/templates/hedge_calculator.html
+++ b/templates/hedge_calculator.html
@@ -138,7 +138,7 @@
       <div id="projectedOutputRow" class="row mb-4">
         <div class="col-md-6 slider-box mb-3">
           <label for="priceSlider" class="form-label"><strong>Simulated Price</strong></label>
-          <input type="range" class="form-range" id="priceSlider" step="0.01" oninput="sliderChanged()">
+          <input type="range" class="form-range" id="priceSlider" step="0.01">
           <div class="d-flex justify-content-between">
             <small id="tickLeft">$0</small>
             <small id="tickRight">$0</small>
@@ -152,7 +152,7 @@
         </div>
         <div class="col-md-6 slider-box mb-3">
           <label for="leverageSlider" class="form-label"><strong>Projected Leverage</strong></label>
-          <input type="range" class="form-range" id="leverageSlider" min="1" max="20" step="0.1" oninput="updateProjectedHeatIndex()">
+          <input type="range" class="form-range" id="leverageSlider" min="1" max="20" step="0.1">
           <div id="leverageValue" class="mt-2">Leverage: 1x</div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove stray hedge_calcutor2 template
- rename updated markup back to hedge_calculator.html
- hook slider events via JavaScript so calculations update

## Testing
- `pytest -q` *(fails: ImportError while importing modules; 43 errors during collection)*