### PR TITLE
Add portfolio & position alert sections

### DIFF
--- a/app/alerts_bp.py
+++ b/app/alerts_bp.py
@@ -138,15 +138,21 @@ def alert_config_page():
         config_data = load_config(str(ALERT_LIMITS_PATH)) or {}
         alert_ranges = config_data.get("alert_ranges", {})
         price_alerts = alert_ranges.get("price_alerts", {})
+        portfolio_alerts = alert_ranges.get("portfolio_alerts", {})
+        positions_alerts = alert_ranges.get("positions_alerts", {})
         global_alert_config = config_data.get("global_alert_config", {})
     except Exception as e:
         logger.error(f"Failed to load alert configuration: {e}", exc_info=True)
         price_alerts = {}
+        portfolio_alerts = {}
+        positions_alerts = {}
         global_alert_config = {}
 
     return render_template(
         "alert_limits.html",
         price_alerts=price_alerts,
+        portfolio_alerts=portfolio_alerts,
+        positions_alerts=positions_alerts,
         global_alert_config=global_alert_config,
     )
 

--- a/config/alert_limits.json
+++ b/config/alert_limits.json
@@ -40,6 +40,15 @@
         "condition": "ABOVE",
         "trigger_value": 133.9
       }
+    },
+    "portfolio_alerts": {
+      "total_value": { "low": 5000, "medium": 25000, "high": 50000, "enabled": true },
+      "total_size": { "low": 1, "medium": 5, "high": 10, "enabled": true }
+    },
+    "positions_alerts": {
+      "heat_index": { "low": 10, "medium": 20, "high": 30, "enabled": true },
+      "travel_percent": { "low": 5, "medium": 10, "high": 20, "enabled": true },
+      "profit": { "low": 5, "medium": 15, "high": 25, "enabled": true }
     }
   },
   "notifications": {

--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -26,6 +26,7 @@
 {% endblock %}
 
 {% block content %}
+{% include "title_bar.html" %}
 <div class="container-fluid pt-4">
   <h1 class="mb-4">Alert Limits</h1>
   <p>This page will hold alert configuration options.</p>
@@ -38,6 +39,12 @@
       </li>
       <li class="nav-item" role="presentation">
         <button class="nav-link" id="price-tab" data-bs-toggle="tab" data-bs-target="#price" type="button" role="tab">Price Alerts</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="portfolio-tab" data-bs-toggle="tab" data-bs-target="#portfolio" type="button" role="tab">Portfolio Alerts</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="positions-tab" data-bs-toggle="tab" data-bs-target="#positions" type="button" role="tab">Position Alerts</button>
       </li>
       <li class="nav-item" role="presentation">
         <button class="nav-link" id="global-tab" data-bs-toggle="tab" data-bs-target="#global" type="button" role="tab">Global Alerts</button>
@@ -61,6 +68,30 @@
             </div>
           </div>
           <div class="accordion-item">
+            <h2 class="accordion-header" id="headingPortfolio">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePortfolio" aria-expanded="false" aria-controls="collapsePortfolio">
+                <i class="fas fa-wallet me-2"></i>Portfolio Alerts
+              </button>
+            </h2>
+            <div id="collapsePortfolio" class="accordion-collapse collapse" aria-labelledby="headingPortfolio" data-bs-parent="#alertLimitsAccordion">
+              <div class="accordion-body">
+                {% include "partials/portfolio_alerts_section.html" %}
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="headingPositions">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePositions" aria-expanded="false" aria-controls="collapsePositions">
+                <i class="fas fa-bell me-2"></i>Position Alerts
+              </button>
+            </h2>
+            <div id="collapsePositions" class="accordion-collapse collapse" aria-labelledby="headingPositions" data-bs-parent="#alertLimitsAccordion">
+              <div class="accordion-body">
+                {% include "partials/positions_alerts_section.html" %}
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
             <h2 class="accordion-header" id="headingGlobal">
               <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseGlobal" aria-expanded="false" aria-controls="collapseGlobal">
                 <i class="fas fa-globe me-2"></i>Global Alerts
@@ -78,6 +109,16 @@
       <!-- Price Tab -->
       <div class="tab-pane fade" id="price" role="tabpanel" aria-labelledby="price-tab">
         {% include "partials/price_alerts_section.html" %}
+      </div>
+
+      <!-- Portfolio Tab -->
+      <div class="tab-pane fade" id="portfolio" role="tabpanel" aria-labelledby="portfolio-tab">
+        {% include "partials/portfolio_alerts_section.html" %}
+      </div>
+
+      <!-- Positions Tab -->
+      <div class="tab-pane fade" id="positions" role="tabpanel" aria-labelledby="positions-tab">
+        {% include "partials/positions_alerts_section.html" %}
       </div>
 
       <!-- Global Tab -->

--- a/templates/partials/portfolio_alerts_section.html
+++ b/templates/partials/portfolio_alerts_section.html
@@ -1,0 +1,31 @@
+<div class="card mb-4">
+  <div class="card-header bg-success text-white">
+    <i class="fas fa-wallet me-2"></i>Portfolio Alerts
+  </div>
+  <div class="card-body">
+    <div class="row g-3">
+      {% for metric, conf in portfolio_alerts.items() %}
+      <div class="col-md-4">
+        <h6 class="text-capitalize">{{ metric.replace('_', ' ') }}</h6>
+        <div class="mb-2">
+          <label class="form-label">Low</label>
+          <input type="number" step="0.01" class="form-control" name="alert_ranges[portfolio_alerts][{{ metric }}][low]" value="{{ conf.get('low', '') }}">
+        </div>
+        <div class="mb-2">
+          <label class="form-label">Medium</label>
+          <input type="number" step="0.01" class="form-control" name="alert_ranges[portfolio_alerts][{{ metric }}][medium]" value="{{ conf.get('medium', '') }}">
+        </div>
+        <div class="mb-2">
+          <label class="form-label">High</label>
+          <input type="number" step="0.01" class="form-control" name="alert_ranges[portfolio_alerts][{{ metric }}][high]" value="{{ conf.get('high', '') }}">
+        </div>
+        <div class="form-check form-switch">
+          <input type="hidden" name="alert_ranges[portfolio_alerts][{{ metric }}][enabled]" value="false">
+          <input type="checkbox" class="form-check-input" name="alert_ranges[portfolio_alerts][{{ metric }}][enabled]" value="true" {% if conf.get('enabled') %}checked{% endif %}>
+          <label class="form-check-label">Enabled</label>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/templates/partials/positions_alerts_section.html
+++ b/templates/partials/positions_alerts_section.html
@@ -1,0 +1,31 @@
+<div class="card mb-4">
+  <div class="card-header bg-warning text-dark">
+    <i class="fas fa-bell me-2"></i>Position Alerts
+  </div>
+  <div class="card-body">
+    <div class="row g-3">
+      {% for metric, conf in positions_alerts.items() %}
+      <div class="col-md-4">
+        <h6 class="text-capitalize">{{ metric.replace('_', ' ') }}</h6>
+        <div class="mb-2">
+          <label class="form-label">Low</label>
+          <input type="number" step="0.01" class="form-control" name="alert_ranges[positions_alerts][{{ metric }}][low]" value="{{ conf.get('low', '') }}">
+        </div>
+        <div class="mb-2">
+          <label class="form-label">Medium</label>
+          <input type="number" step="0.01" class="form-control" name="alert_ranges[positions_alerts][{{ metric }}][medium]" value="{{ conf.get('medium', '') }}">
+        </div>
+        <div class="mb-2">
+          <label class="form-label">High</label>
+          <input type="number" step="0.01" class="form-control" name="alert_ranges[positions_alerts][{{ metric }}][high]" value="{{ conf.get('high', '') }}">
+        </div>
+        <div class="form-check form-switch">
+          <input type="hidden" name="alert_ranges[positions_alerts][{{ metric }}][enabled]" value="false">
+          <input type="checkbox" class="form-check-input" name="alert_ranges[positions_alerts][{{ metric }}][enabled]" value="true" {% if conf.get('enabled') %}checked{% endif %}>
+          <label class="form-check-label">Enabled</label>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- extend alert limits blueprint to load portfolio & position alert settings
- include new accordion sections and tabs in alert limits UI
- add partial templates for portfolio & position alert forms
- set default portfolio & position alert thresholds in config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts', 'rich', etc.)*
