### PR TITLE
Fix title bar styles on alert limits page

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -8,6 +8,7 @@
 
 {% block extra_styles %}
   {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <style>
     .save-spinner {
       display: none;


### PR DESCRIPTION
## Summary
- include title bar stylesheet on the alert limits page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*