### PR TITLE
Improve alert status page visuals

### DIFF
--- a/static/css/alert_status.css
+++ b/static/css/alert_status.css
@@ -23,11 +23,11 @@
 }
 
 .positions-table thead th {
-  background: #222e3a;
-  color: #fff;
+  background: var(--title-bar-bg);
+  color: var(--panel-title);
   font-weight: 700;
   padding: 0.7em 0.6em;
-  border-bottom: 2px solid #c0d7f5;
+  border-bottom: 2px solid var(--panel-border);
   user-select: none;
   cursor: pointer;
   vertical-align: middle;
@@ -40,17 +40,17 @@
 
 .positions-table tbody td {
   background: var(--container-bg);
-  color: #111;
+  color: var(--text);
   padding: 0.7em 0.6em;
-  border-bottom: 1px solid #e6ecf8;
+  border-bottom: 1px solid var(--panel-border);
   vertical-align: middle;
 }
 
 .positions-table tfoot th {
-  background: #f6fafd;
-  color: #222;
+  background: var(--accent);
+  color: var(--text);
   font-weight: bold;
-  border-top: 2px solid #c0d7f5;
+  border-top: 2px solid var(--panel-border);
   text-align: right;
 }
 .positions-table tfoot th.left { text-align: left; }
@@ -58,26 +58,19 @@
 .sort-indicator {
   font-size: 1em;
   margin-left: 4px;
-  color: #fffbe6;
+  color: var(--panel-title);
   opacity: 0.8;
 }
-th.sorted-asc .sort-indicator { color: #ffe97a; }
-th.sorted-desc .sort-indicator { color: #ffe97a; }
+th.sorted-asc .sort-indicator { color: var(--primary); }
+th.sorted-desc .sort-indicator { color: var(--primary); }
 
 .no-data {
   text-align: center;
-  color: #888;
+  color: var(--text);
   padding: 1.2rem;
   font-style: italic;
 }
-@media (prefers-color-scheme: dark), :root[data-theme="dark"] {
-  .positions-table tbody td {
-    color: #ffffff;
-  }
-}
-:root[data-theme="dark"] .positions-table tbody td {
-  color: #ffffff !important;
-}
+
 
 /* Align bars rows with table rows */
 .alert-bars #alertBars {
@@ -88,6 +81,6 @@ th.sorted-desc .sort-indicator { color: #ffe97a; }
 .alert-bars .liq-row {
   padding: 0.7em 0.6em;
   margin: 0;
-  border-bottom: 1px solid #e6ecf8;
+  border-bottom: 1px solid var(--panel-border);
   background: var(--container-bg);
 }

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -18,24 +18,40 @@
   <div class="sonic-content-panel">
       <div class="alert-table">
         <div class="section-title">Alerts</div>
+        {% set type_icons = {
+          'pricethreshold': '💵',
+          'deltachange': '📊',
+          'travelpercentliquid': '🚨',
+          'time': '⏰',
+          'profit': '💰',
+          'heatindex': '🔥',
+          'totalvalue': '💰',
+          'totalsize': '📦',
+          'avgleverage': '🎚️',
+          'valuetocollateralratio': '⚖️',
+          'avgtravelpercent': '🚀',
+          'totalheat': '🔥'
+        } %}
         <div class="positions-table-wrapper">
           <table class="positions-table alerts-table">
         <thead>
           <tr>
             <th class="sortable left" data-col-index="0">Asset <span class="sort-indicator"></span></th>
             <th class="sortable left" data-col-index="1">Type <span class="sort-indicator"></span></th>
-            <th class="sortable right" data-col-index="2">Current <span class="sort-indicator"></span></th>
-            <th class="sortable right" data-col-index="3">Trigger <span class="sort-indicator"></span></th>
-            <th class="sortable left" data-col-index="4">Level <span class="sort-indicator"></span></th>
-            <th class="sortable left" data-col-index="5">Status <span class="sort-indicator"></span></th>
+            <th class="sortable left" data-col-index="2">Class <span class="sort-indicator"></span></th>
+            <th class="sortable right" data-col-index="3">Current <span class="sort-indicator"></span></th>
+            <th class="sortable right" data-col-index="4">Trigger <span class="sort-indicator"></span></th>
+            <th class="sortable left" data-col-index="5">Level <span class="sort-indicator"></span></th>
+            <th class="sortable left" data-col-index="6">Status <span class="sort-indicator"></span></th>
           </tr>
         </thead>
         <tbody>
           {% if alerts %}
             {% for alert in alerts %}
             <tr data-alert-id="{{ alert.id }}">
-              <td class="left">{{ alert.asset or 'N/A' }}</td>
-              <td class="left">{{ alert.alert_type }}</td>
+              <td class="left"><img class="asset-icon" src="{{ url_for('static', filename='images/' + alert.asset_image) }}" alt="{{ alert.asset }}"><span style="display:none">{{ alert.asset or 'N/A' }}</span></td>
+              <td class="left">{{ type_icons.get(alert.alert_type, '❓') }}</td>
+              <td class="left">{{ alert.alert_class }}</td>
               <td class="right">{{ "{:,.2f}".format(alert.evaluated_value or 0) }}</td>
               <td class="right">{{ "{:,.2f}".format(alert.trigger_value or 0) }}</td>
               <td class="left">{{ alert.level }}</td>
@@ -43,7 +59,7 @@
             </tr>
             {% endfor %}
           {% else %}
-            <tr class="no-data-row"><td colspan="6" class="no-data">No alerts available.</td></tr>
+            <tr class="no-data-row"><td colspan="7" class="no-data">No alerts available.</td></tr>
           {% endif %}
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
- add icon mappings for alert type
- display asset as an image and show alert class
- update status table markup
- theme-friendly colors for alert page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*