### PR TITLE
Rename alert_limits key to alert_ranges

### DIFF
--- a/alert_core/tests/test_alert_core_barrage.py
+++ b/alert_core/tests/test_alert_core_barrage.py
@@ -30,11 +30,9 @@ alert_core = AlertCore(dl, lambda: {
         "profit": {"low": 10, "medium": 100, "high": 500},
         "heatindex": {"low": 2, "medium": 5, "high": 9},
         "travelpercentliquid": {"low": 10, "medium": 25, "high": 50},
-    },
-    "alert_limits": {
         "profit_ranges": {"low": 10, "medium": 100, "high": 500, "enabled": True},
         "heat_index_ranges": {"low": 2, "medium": 5, "high": 9, "enabled": True},
-        "travel_percent_liquid_ranges": {"low": 10, "medium": 25, "high": 50, "enabled": True},
+        "travel_percent_liquid_ranges": {"low": 10, "medium": 25, "high": 50, "enabled": True}
     }
 })
 

--- a/config/alert_limits.json
+++ b/config/alert_limits.json
@@ -1,5 +1,5 @@
 {
-  "alert_limits": {
+  "alert_ranges": {
     "liquidation_distance_ranges": {
       "enabled": true,
       "low": 10.0,

--- a/data/test_travel_percent_lifecycle.py
+++ b/data/test_travel_percent_lifecycle.py
@@ -65,9 +65,7 @@ def set_price(dl, asset, price):
 def config_loader():
     return {
         "alert_ranges": {
-            "travelpercentliquid": {"low": 10, "medium": 25, "high": 50}
-        },
-        "alert_limits": {
+            "travelpercentliquid": {"low": 10, "medium": 25, "high": 50},
             "travel_percent_liquid_ranges": {
                 "low": 10,
                 "medium": 25,

--- a/tests/test_heat_index_alert.py
+++ b/tests/test_heat_index_alert.py
@@ -19,8 +19,8 @@ def test_heat_index_limits_validation():
 
     # === Load Config ===
     config = load_config(str(ALERT_LIMITS_PATH))
-    alert_limits = config.get("alert_limits", config)
-    tpl = alert_limits.get("total_portfolio_limits", {})
+    alert_ranges = config.get("alert_ranges", config)
+    tpl = alert_ranges.get("total_portfolio_limits", {})
     assert "total_heat_limits" in tpl, "❌ 'total_heat_limits' missing in config"
 
     thresholds = tpl["total_heat_limits"]

--- a/tests/test_portfolio_alerts_EE.py
+++ b/tests/test_portfolio_alerts_EE.py
@@ -37,9 +37,9 @@ def test_portfolio_alerts_EE_multirun():
     # ✅ Step 1: Load config
     try:
         config = load_config(str(ALERT_LIMITS_PATH))
-        alert_limits = config.get("alert_limits", config)
-        log.info(f"Loaded alert_limits keys: {list(alert_limits.keys())}", source="ConfigLoader")
-        assert "total_portfolio_limits" in alert_limits, "Missing 'total_portfolio_limits' in config"
+        alert_ranges = config.get("alert_ranges", config)
+        log.info(f"Loaded alert_ranges keys: {list(alert_ranges.keys())}", source="ConfigLoader")
+        assert "total_portfolio_limits" in alert_ranges, "Missing 'total_portfolio_limits' in config"
         log.success("✅ Alert configuration loaded and validated", source="ConfigLoader")
     except Exception as e:
         raise AssertionError(f"❌ Failed to load alert config: {e}")

--- a/tests/test_schema_validation_service.py
+++ b/tests/test_schema_validation_service.py
@@ -10,9 +10,9 @@ TEST_BROKEN_JSON_FILE = "tests/mock_broken_json.json"
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_mock_files():
-    # Valid mock alert_limits
+    # Valid mock alert_ranges
     valid_data = {
-        "alert_limits": {
+        "alert_ranges": {
             "liquidation_distance_ranges": {},
             "travel_percent_liquid_ranges": {},
             "heat_index_ranges": {},
@@ -32,7 +32,7 @@ def setup_mock_files():
     }
 
     invalid_schema_data = {
-        "alert_limits": {
+        "alert_ranges": {
             "liquidation_distance_ranges": {},
             "travel_percent_liquid_ranges": {},
             "heat_index_ranges": {}
@@ -50,7 +50,7 @@ def setup_mock_files():
         }
     }
 
-    broken_json_content = """{ "alert_limits": { "liquidation_distance_ranges": {} }"""  # Missing closing }
+    broken_json_content = """{ \"alert_ranges\": { \"liquidation_distance_ranges\": {} }"""  # Missing closing }
 
     os.makedirs("tests", exist_ok=True)
     with open(TEST_VALID_FILE, "w") as f:
@@ -69,13 +69,13 @@ def setup_mock_files():
     os.remove(TEST_INVALID_SCHEMA_FILE)
     os.remove(TEST_BROKEN_JSON_FILE)
 
-def test_valid_alert_limits():
+def test_valid_alert_ranges():
     assert SchemaValidationService.validate_schema(TEST_VALID_FILE, SchemaValidationService.ALERT_LIMITS_SCHEMA, name="Mock Valid Limits")
 
-def test_invalid_schema_alert_limits():
+def test_invalid_schema_alert_ranges():
     assert not SchemaValidationService.validate_schema(TEST_INVALID_SCHEMA_FILE, SchemaValidationService.ALERT_LIMITS_SCHEMA, name="Mock Invalid Schema")
 
-def test_missing_alert_limits_file():
+def test_missing_alert_ranges_file():
     assert not SchemaValidationService.validate_schema(TEST_MISSING_FILE, SchemaValidationService.ALERT_LIMITS_SCHEMA, name="Mock Missing File")
 
 def test_broken_json_file():

--- a/utils/schema_validation_service.py
+++ b/utils/schema_validation_service.py
@@ -19,7 +19,7 @@ class SchemaValidationService:
     ALERT_LIMITS_SCHEMA = {
         "type": "object",
         "properties": {
-            "alert_limits": {
+            "alert_ranges": {
                 "type": "object",
                 "properties": {
                     "liquidation_distance_ranges": {"type": "object"},
@@ -59,7 +59,7 @@ class SchemaValidationService:
                 }
             }
         },
-        "required": ["alert_limits", "cooldowns", "notifications"]
+        "required": ["alert_ranges", "cooldowns", "notifications"]
     }
 
     @staticmethod
@@ -85,8 +85,8 @@ class SchemaValidationService:
             return False
 
     @classmethod
-    def validate_alert_limits(cls):
-        return cls.validate_schema(cls.ALERT_LIMITS_FILE, cls.ALERT_LIMITS_SCHEMA, name="Alert Limits")
+    def validate_alert_ranges(cls):
+        return cls.validate_schema(cls.ALERT_LIMITS_FILE, cls.ALERT_LIMITS_SCHEMA, name="Alert Ranges")
 
     @classmethod
     def batch_validate(cls):
@@ -95,7 +95,7 @@ class SchemaValidationService:
         results = []
 
         validations = [
-            ("Alert Limits", cls.ALERT_LIMITS_FILE, cls.ALERT_LIMITS_SCHEMA)
+            ("Alert Ranges", cls.ALERT_LIMITS_FILE, cls.ALERT_LIMITS_SCHEMA)
             # Future: add more configs here
         ]
 


### PR DESCRIPTION
## Summary
- rename `alert_limits` key to `alert_ranges` in config
- update schema validation service for new key
- adjust tests and scripts that referenced `alert_limits`

## Testing
- `pytest -q` *(fails: 43 errors during collection)*