### PR TITLE
Fix Hedge Calculator theme and toggling

### DIFF
--- a/static/js/hedge_calculator_config.js
+++ b/static/js/hedge_calculator_config.js
@@ -84,3 +84,14 @@ document.getElementById('saveModifiers').addEventListener('click', async () => {
     alert('Failed to save modifiers');
   }
 });
+
+const toggleBtn = document.getElementById('toggleConfig');
+const configSection = document.getElementById('configSection');
+if (toggleBtn && configSection) {
+  toggleBtn.addEventListener('click', () => {
+    const hidden = configSection.style.display === 'none';
+    configSection.style.display = hidden ? '' : 'none';
+    toggleBtn.title = hidden ? 'Hide Config' : 'Show Config';
+    toggleBtn.innerHTML = hidden ? '<i class="fa-solid fa-eye-slash"></i>' : '<i class="fa-solid fa-eye"></i>';
+  });
+}

--- a/templates/hedge_calculator.html
+++ b/templates/hedge_calculator.html
@@ -5,6 +5,8 @@
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_calculator.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -26,6 +28,9 @@
   <div class="card shadow mb-4">
     <div class="card-header position-relative" style="background-color: var(--card-title-color);">
       <h4 class="mb-0 text-center" style="color: var(--text-color);">🦔 Hedge Calculator</h4>
+      <button id="toggleConfig" class="btn btn-sm btn-outline-secondary position-absolute" style="top: 10px; right: 50px;" title="Hide Config">
+        <i class="fa-solid fa-eye-slash"></i>
+      </button>
       <button id="saveModifiers" class="btn btn-sm btn-outline-secondary position-absolute" style="top: 10px; right: 10px;" title="Save Modifiers">
         <i class="fa-solid fa-floppy-disk"></i>
       </button>
@@ -40,6 +45,12 @@
   window.longPositionsData = {{ long_positions | tojson }};
   window.shortPositionsData = {{ short_positions | tojson }};
 </script>
+
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+{% endblock %}
 
 {% endblock %}
 

--- a/templates/hedge_calculator_config.html
+++ b/templates/hedge_calculator_config.html
@@ -1,6 +1,7 @@
 <!-- Hedge Calculator Configuration Section -->
 <link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_calculator_config.css') }}">
 <!-- Rows 1-3 from hedge_calculator.html -->
+<div id="configSection">
 <div id="positionInputRow" class="row mb-4">
   <div class="col-md-6 mb-3">
     <div class="border rounded p-3" style="background-color: #f7f7f7;">
@@ -100,5 +101,6 @@
       <label class="btn btn-outline-primary" for="approachAggressive">Aggressive</label>
     </div>
   </div>
+</div>
 </div>
 <script src="{{ url_for('static', filename='js/hedge_calculator_config.js') }}"></script>


### PR DESCRIPTION
## Summary
- integrate sonic theme styling in the Hedge Calculator page
- add hide/show toggle for the configuration section
- ensure layout modes and themes apply to Hedge Calculator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*