### PR TITLE
Fix alert limits theme control

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -9,6 +9,8 @@
 {% block extra_styles %}
   {{ super() }}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
   <style>
     .save-spinner {
       display: none;
@@ -130,4 +132,9 @@
 
   </form>
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- include sonic theme and layout assets for alert limits page
- load title bar scripts for theme and size toggles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: rich)*