### PR TITLE
Fix alert status theme toggle and icon size

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -21,7 +21,7 @@
   align-items: center;
   justify-content: center;
   padding: 0.18rem 0.55rem;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   min-width: 42px;
   min-height: 42px;
   border-radius: 10px;
@@ -39,7 +39,7 @@
 .layout-toggle-btn {
   border-radius: 10px;
   border: 1.5px solid #d2cdf7;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   padding: 0.18rem 0.55rem;
 }
 .theme-toggle-group {
@@ -51,7 +51,7 @@
   border: 1.5px solid #d2cdf7;
   border-radius: 10px;
   padding: 0.18rem 0.55rem;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   background: #fff;
   color: #444;
   cursor: pointer;

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -162,5 +162,6 @@ document.addEventListener("DOMContentLoaded", function() {
   sortTable(currentSort.col, currentSort.dir);
 });
 </script>
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
 <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure alert status page loads theme toggle script
- shrink title bar icons for consistency across pages

## Testing
- `pytest -q` *(fails: 43 errors during collection)*