### PR TITLE
Add Cyclone Core specification

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -6,6 +6,7 @@ This repository contains multiple subsystems that make up the overall trading an
 
 ### Cyclone
 The [Cyclone module](cyclone/cyclone_module_spec.md) drives workflow orchestration and alert management. It processes market updates, evaluates portfolio risk and positions, generates alerts, and coordinates hedging logic.
+For a focused look at the main engine see the [Cyclone Core specification](cyclone/cyclone_core_spec.md).
 
 ### Positions
 The [Positions module](positions/position_module_spec.md) manages trading positions. It handles enrichment of positions with risk metrics, synchronization with external services, grouping for hedge analysis, and database persistence.

--- a/cyclone/cyclone_core_spec.md
+++ b/cyclone/cyclone_core_spec.md
@@ -1,0 +1,59 @@
+# 🌪️ Cyclone Core Specification
+
+> Version: `v1.0`
+> Author: `CoreOps 🥷`
+> Scope: Orchestration engine for market updates, position enrichment, alert creation, hedge linkage, and reporting.
+
+---
+
+## 📂 Module Structure
+```txt
+cyclone/
+├── cyclone_engine.py          # 🌪️ Cyclone class and run_cycle entry point
+├── cyclone_alert_service.py   # 🚨 Generates and evaluates alerts
+├── cyclone_position_service.py# 📊 Position operations and enrichment
+├── cyclone_portfolio_service.py # 📈 Portfolio alert helpers
+├── cyclone_hedge_service.py   # 🔗 Hedge detection wrapper
+├── cyclone_wallet_service.py  # 👛 Wallet management utilities
+├── cyclone_report_generator.py# 📝 HTML report builder
+├── cyclone_console/           # 🎛️ Rich CLI interface
+├── cyclone_bp.py              # 🌐 Flask Blueprint endpoints
+```
+
+## 🌪️ `Cyclone` Class
+Central orchestrator defined in `cyclone_engine.py`.
+
+### Constructor
+```python
+Cyclone(monitor_core, poll_interval=60)
+```
+- Initializes a shared `DataLocker` instance.
+- Creates `PositionCore`, `AlertCore`, `PriceSyncService`, and helper services.
+- Configures the central logger via `configure_cyclone_console_log()`.
+
+### Key Methods
+- `async run_cycle(steps=None)` – runs a sequence of operations such as price updates, position enrichment, hedge linking, and alert evaluation.
+- `async run_market_updates()` – fetches latest prices using `PriceSyncService`.
+- `async run_enrich_positions()` – enriches all positions via `PositionCore`.
+- `async run_create_position_alerts()` – generates position level alerts.
+- `async run_create_portfolio_alerts()` – generates portfolio level alerts.
+- `async run_alert_evaluation()` – evaluates alert levels after enrichment.
+- `async run_link_hedges()` – detects hedge pairs using `CycloneHedgeService`.
+- `async run_cleanse_ids()` – clears stale alerts from the datastore.
+
+Each method logs progress with emojis and delegates to the appropriate service or core module.
+
+## 🧩 Integrations
+- **DataLocker** – provides persistence for alerts, prices, positions, and system variables.
+- **AlertCore** – all alert creation and evaluation flows.
+- **PositionCore** – position synchronization and enrichment.
+- **MonitorCore** – optional monitoring callbacks during `run_cycle`.
+- **Flask API** – `cyclone_bp.py` exposes HTTP endpoints that call into the same run methods.
+- **Console** – `cyclone_console` offers an interactive menu using the `rich` library.
+
+## ✅ Design Notes
+- Steps are asynchronous and can be executed individually or as a full cycle.
+- Centralized logging tags each message with the Cyclone source for clarity.
+- Error handling in `run_cycle` emits "death" events through `SystemCore` when a step fails fatally.
+- The architecture keeps services thin so logic is reusable in both CLI and API contexts.
+


### PR DESCRIPTION
## Summary
- document Cyclone engine behavior in a new `cyclone_core_spec.md`
- link the new spec from the specification index

## Testing
- `pytest -q` *(fails: 43 errors during collection)*