### PR TITLE
Add layout container to alert limits page

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -30,7 +30,8 @@
 
 {% block content %}
 {% include "title_bar.html" %}
-<div class="container-fluid pt-4">
+<div class="sonic-section-container sonic-section-middle mt-3">
+  <div class="sonic-content-panel">
   <h1 class="mb-4">Alert Limits</h1>
   <p>This page will hold alert configuration options.</p>
 
@@ -131,6 +132,7 @@
     </div>
 
   </form>
+  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- wrap alert limits page in `sonic-section-container` and `sonic-content-panel`
- keep layout toggle scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts', etc.)*