### PR TITLE
Fix Hedge Calculator size update

### DIFF
--- a/static/js/hedge_calculator_results.js
+++ b/static/js/hedge_calculator_results.js
@@ -95,4 +95,12 @@ document.addEventListener('DOMContentLoaded', () => {
   if (leverageSlider) {
     leverageSlider.addEventListener('input', updateProjectedHeatIndex);
   }
+  const longSizeInput = document.getElementById('longSize');
+  if (longSizeInput) {
+    longSizeInput.addEventListener('input', sliderChanged);
+  }
+  const shortSizeInput = document.getElementById('shortSize');
+  if (shortSizeInput) {
+    shortSizeInput.addEventListener('input', sliderChanged);
+  }
 });


### PR DESCRIPTION
## Summary
- update hedge calculator JS to recompute values when size inputs change

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*