### PR TITLE
Add monitor core spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # v0.8
 
 For an overview of the key modules and architecture, see
-[SPECIFICATIONS.md](SPECIFICATIONS.md).
+[SPECIFICATIONS.md](SPECIFICATIONS.md). This now includes the
+[Monitor Core specification](monitor/monitor_module_spec.md).
 
 ## Twilio Testing
 

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -22,6 +22,9 @@ The [Sonic Data module](data/sonic_data_module_spec.md) defines the core data mo
 ### Calculation Core
 The [Calculation Core module](calc_core/calculation_module_spec.md) houses risk calculations and hedge utilities. It exposes pure math services, loads modifier weights, updates position metrics, and groups hedges for analysis.
 
+### Monitor Core
+The [Monitor module](monitor/monitor_module_spec.md) drives periodic tasks and health checks. It registers individual monitors and exposes CLI and API entrypoints for running them.
+
 ---
 
 Each linked specification contains more detailed design notes, functional requirements, and example workflows.

--- a/monitor/monitor_module_spec.md
+++ b/monitor/monitor_module_spec.md
@@ -1,0 +1,51 @@
+# 🛰️ Monitor Core Specification
+
+> Version: `v1.0`
+> Author: `CoreOps 🥷`
+> Scope: Monitor orchestrator and supporting monitors.
+
+---
+
+## 📂 Module Structure
+
+```txt
+monitor/
+├── monitor_core.py         # 🚦 Registers and runs monitors
+├── base_monitor.py         # 🔧 Shared run_cycle/ledger wrapper
+├── monitor_registry.py     # 📇 Holds monitor instances
+├── price_monitor.py        # 💰 Fetches prices from APIs
+├── position_monitor.py     # 📈 Syncs and enriches positions
+├── operations_monitor.py   # 🧪 Startup POST tests and health checks
+├── latency_monitor.py      # ⏱️ External API latency checker
+├── ledger_service.py       # 🧾 JSON ledger utilities
+├── monitor_api.py          # 🌐 Flask API endpoints
+└── sonic_monitor.py        # ❤️ Background cycle runner
+```
+
+### 🚦 MonitorCore
+Central controller for executing registered monitors.
+
+```python
+MonitorCore(registry: Optional[MonitorRegistry] = None)
+```
+- If `registry` is not provided, a new one is created and default monitors are registered (`PriceMonitor`, `PositionMonitor`, `OperationsMonitor`).
+
+**Methods**
+- `run_all()` – iterate and run every monitor in the registry, logging success or failure.
+- `run_by_name(name)` – run a single monitor by its key if present.
+
+### 🧩 Monitor Implementations
+- **BaseMonitor** – provides `run_cycle()` wrapper that records results in the database ledger.
+- **PriceMonitor** – fetches BTC/ETH/SOL prices via `MonitorService`.
+- **PositionMonitor** – syncs positions from Jupiter and logs summary metrics.
+- **OperationsMonitor** – runs POST tests on startup and stores results.
+- **LatencyMonitor** – optional HTTP latency checker for third-party services.
+
+### 🌐 API & Background Runner
+- `monitor_api.py` exposes REST endpoints to trigger monitors individually or all at once.
+- `sonic_monitor.py` runs periodic cycles using `Cyclone` and records a heartbeat in the database.
+
+### ✅ Design Notes
+- Monitors write a summary entry to the ledger table via `DataLocker.ledger`.
+- Registration through `MonitorRegistry` keeps monitor setup centralized.
+- Execution paths include CLI scripts, Flask API, and long‑running background loops.


### PR DESCRIPTION
## Summary
- document the monitor domain under a new spec file
- link to the monitor spec in the specification index
- note the new monitor module docs in the README

## Testing
- `pytest -q` *(fails: 43 errors during collection)*