### PR TITLE
Expand alert limits panel width

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -25,13 +25,18 @@
       0% { transform: rotate(0deg); }
       100% { transform: rotate(360deg); }
     }
+
+    .alert-limits-panel {
+      max-width: 800px;
+      width: 100%;
+    }
   </style>
 {% endblock %}
 
 {% block content %}
 {% include "title_bar.html" %}
 <div class="sonic-section-container sonic-section-middle mt-3">
-  <div class="sonic-content-panel">
+  <div class="sonic-content-panel alert-limits-panel">
   <h1 class="mb-4">Alert Limits</h1>
   <p>This page will hold alert configuration options.</p>
 


### PR DESCRIPTION
## Summary
- make alert limits panel larger so the form fills more of the screen

## Testing
- `pytest -q` *(fails: 43 errors during collection)*