### PR TITLE
Fix xcom settings theme toggles

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
   {% block head %}{% endblock %}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/icons.css') }}">
   {% block extra_styles %}{% endblock %}
 </head>

--- a/templates/system/xcom_config.html
+++ b/templates/system/xcom_config.html
@@ -2,8 +2,11 @@
 
 {% block title %}XCom Settings{% endblock %}
 
-{% block head %}
+{% block extra_styles %}
+{{ super() }}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -163,4 +166,9 @@ function toggleToken() {
   field.type = field.type === "password" ? "text" : "password";
 }
 </script>
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- include Font Awesome icons globally
- load theme/layout CSS & JS for xcom settings page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*