### PR TITLE
Load comm secrets from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,27 @@ The script loads credentials from the `.env` file (or environment variables) and
 uses `scripts/twilio_test.py` to perform the authentication and optional flow
 execution.
 
+## Required Environment Variables
+
+The application expects several environment variables for email and Twilio
+integration. Create a `.env` file or export them in your shell before running
+the app:
+
+```
+SMTP_SERVER=your.smtp.server
+SMTP_PORT=587
+SMTP_USERNAME=you@example.com
+SMTP_PASSWORD=your_password
+SMTP_DEFAULT_RECIPIENT=you@example.com
+
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_FROM_PHONE=+15555555555
+TWILIO_TO_PHONE=+15555555555
+# Optional
+TWILIO_FLOW_SID=FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
 ## Hedge Calculator
 
 ## Threshold Seeder

--- a/sonic_app.py
+++ b/sonic_app.py
@@ -6,7 +6,10 @@ Main Flask app for Sonic Dashboard.
 
 import os
 import sys
+from dotenv import load_dotenv
+
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+load_dotenv()
 
 from flask import Flask, redirect, url_for, current_app, jsonify
 from flask_socketio import SocketIO
@@ -64,14 +67,14 @@ app.register_blueprint(settings_bp)
 with app.app_context():
     providers = app.data_locker.system.get_var("xcom_providers") or {}
     providers["email"] = {
-        "enabled": False, #True,
+        "enabled": False,  # True,
         "smtp": {
-            "server": "smtp.gmail.com",
-            "port": 587,
-            "username": "bubba.diego@gmail.com",
-            "password": "pzix taan afbe igxb",
-            "default_recipient": "bubba.diego@gmail.com"
-        }
+            "server": os.getenv("SMTP_SERVER"),
+            "port": int(os.getenv("SMTP_PORT", "0")) if os.getenv("SMTP_PORT") else None,
+            "username": os.getenv("SMTP_USERNAME"),
+            "password": os.getenv("SMTP_PASSWORD"),
+            "default_recipient": os.getenv("SMTP_DEFAULT_RECIPIENT"),
+        },
     }
     app.data_locker.system.set_var("xcom_providers", providers)
     print("✅ Default email provider set in xcom_providers")

--- a/xcom/xcom_config_service.py
+++ b/xcom/xcom_config_service.py
@@ -1,6 +1,7 @@
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from flask import current_app
 from core.logging import log
 
@@ -20,12 +21,23 @@ class XComConfigService:
                 provider = {
                     "enabled": True,
                     "smtp": {
-                        "server": "smtp.gmail.com",
-                        "port": 587,
-                        "username": "bubba.diego@gmail.com",
-                        "password": "pzix taan afbe igxb",
-                        "default_recipient": "bubba.diego@gmail.com"
-                    }
+                        "server": os.getenv("SMTP_SERVER"),
+                        "port": int(os.getenv("SMTP_PORT", "0")) if os.getenv("SMTP_PORT") else None,
+                        "username": os.getenv("SMTP_USERNAME"),
+                        "password": os.getenv("SMTP_PASSWORD"),
+                        "default_recipient": os.getenv("SMTP_DEFAULT_RECIPIENT"),
+                    },
+                }
+
+            # Fallback for Twilio if missing/empty
+            if name == "twilio" and not provider:
+                provider = {
+                    "enabled": True,
+                    "account_sid": os.getenv("TWILIO_ACCOUNT_SID"),
+                    "auth_token": os.getenv("TWILIO_AUTH_TOKEN"),
+                    "flow_sid": os.getenv("TWILIO_FLOW_SID"),
+                    "default_to_phone": os.getenv("TWILIO_TO_PHONE"),
+                    "default_from_phone": os.getenv("TWILIO_FROM_PHONE"),
                 }
             return provider
         except Exception as e:


### PR DESCRIPTION
## Summary
- avoid storing SMTP or Twilio credentials in code
- read environment variables on Flask startup using `python-dotenv`
- update fallback config service to check environment variables
- document all required variables in the README

## Testing
- `pytest -q` *(fails: 43 errors during collection)*