### PR TITLE
Add XCom monitor

### DIFF
--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -6,6 +6,7 @@ from core.logging import log
 from positions.position_core import PositionCore
 from data.data_locker import DataLocker
 from utils.json_manager import JsonManager, JsonType
+from xcom.xcom_core import get_latest_xcom_monitor_entry
 #from monitor.ledger_service import LedgerService
 
 from data.data_locker import DataLocker
@@ -168,29 +169,10 @@ def get_latest_operations_monitor_history(dl):
 
 def get_latest_xcom_monitor_history(dl):
     try:
-        entry = dl.ledger.get_last_entry("xcom_monitor")
-        if not entry: return []
-        meta = entry.get("metadata")
-        if isinstance(meta, str):
-            meta = json.loads(meta)
-        results = meta.get("results", {}) or {}
-
-        comm_types = [("sms", "sms"), ("voice", "voice"), ("email", "email"), ("sound", "sound")]
-        comm_type = "system"
-        for key, value in comm_types:
-            if results.get(key):
-                comm_type = key
-                break
-        if comm_type == "system" and meta.get("level", "").lower() == "high":
-            comm_type = "alert"
-        # Use explicit initiator if present, else fallback
-        source = meta.get("initiator") or "system"
-        ts = format_short_time(entry.get("timestamp"))
-        return [{
-            "comm_type": comm_type,
-            "source": source,
-            "timestamp": ts
-        }]
+        entry = get_latest_xcom_monitor_entry(dl)
+        if not entry:
+            return []
+        return [entry]
     except Exception:
         return []
 

--- a/monitor/monitor_core.py
+++ b/monitor/monitor_core.py
@@ -7,6 +7,7 @@ from core.logging import log
 from monitor.price_monitor import PriceMonitor
 from monitor.position_monitor import PositionMonitor
 from monitor.operations_monitor import OperationsMonitor
+from monitor.xcom_monitor import XComMonitor
 # Add any new monitors here
 
 from monitor.monitor_registry import MonitorRegistry
@@ -21,6 +22,7 @@ class MonitorCore:
         self.registry.register("price_monitor", PriceMonitor())
         self.registry.register("position_monitor", PositionMonitor())
         self.registry.register("operations_monitor", OperationsMonitor())
+        self.registry.register("xcom_monitor", XComMonitor())
         # Add more monitors as needed
 
     def run_all(self):

--- a/monitor/xcom_monitor.py
+++ b/monitor/xcom_monitor.py
@@ -1,0 +1,28 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from monitor.base_monitor import BaseMonitor
+from data.data_locker import DataLocker
+from xcom.xcom_core import XComCore
+from core.core_imports import DB_PATH
+from core.logging import log
+
+
+class XComMonitor(BaseMonitor):
+    """Simple monitor to send a lightweight XCom notification."""
+
+    def __init__(self):
+        super().__init__(name="xcom_monitor", ledger_filename="xcom_ledger.json")
+        self.dl = DataLocker(str(DB_PATH))
+        self.xcom = XComCore(self.dl)
+
+    def _do_work(self):
+        log.info("📡 Sending XCom monitor ping", source="XComMonitor")
+        result = self.xcom.send_notification(
+            level="LOW",
+            subject="XCom Monitor Ping",
+            body="XCom monitor cycle notification",
+            initiator="monitor"
+        )
+        return result

--- a/templates/monitor_cards.html
+++ b/templates/monitor_cards.html
@@ -41,6 +41,12 @@
                   </li>
                 {% endfor %}
               </ul>
+            {% elif item.title == "Xcom" %}
+              <ul class="mini-list">
+                {% for xc in xcom_monitor_history %}
+                  <li>{{ xc.comm_type }} from {{ xc.source }} @ {{ xc.timestamp }}</li>
+                {% endfor %}
+              </ul>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- implement `XComMonitor` for lightweight notification via XComCore
- register new monitor in MonitorCore
- surface latest xcom monitor entry in dashboard logic
- show Xcom history in monitor cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*