### PR TITLE
Fix alert limits width

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -27,14 +27,13 @@
     }
 
     .alert-limits-panel {
-
       width: 100%;
-      max-width: 1100px;
+      max-width: none;
+      margin: 0 auto;
     }
     body.wide-mode .alert-limits-panel,
     body.fitted-mode .alert-limits-panel {
-      max-width: 1100px;
-
+      max-width: none;
     }
   </style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- widen and center the alert limits panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: rich, jsonschema)*