### PR TITLE
Load secrets from env

### DIFF
--- a/config/com_config.json
+++ b/config/com_config.json
@@ -4,13 +4,13 @@
       "email": {
         "enabled": true,
         "smtp": {
-          "server": "smtp.gmail.com",
-          "port": 587,
-          "username": "bubba.diego@gmail.com",
-          "password": "pzix taan afbe igxb",
-          "default_recipient": "bubba.diego@gmail.com"
+          "server": "${SMTP_SERVER}",
+          "port": "${SMTP_PORT}",
+          "username": "${SMTP_USERNAME}",
+          "password": "${SMTP_PASSWORD}",
+          "default_recipient": "${SMTP_DEFAULT_RECIPIENT}"
         }
-      },     
+      },
       "api_config": {
         "coingecko_api_enabled":    "ENABLE",
         "coinmarketcap_api_enabled":"ENABLE",
@@ -26,11 +26,11 @@
       },
       "twilio": {
         "enabled": true,
-        "account_sid": "ACb606788ada5dccbfeeebed0f440099b3",
-        "auth_token": "4a44ade7492e8aac43cb05342f74c492",
-        "flow_sid": "FW5b3bf49ee04af4d23a118b613bbc0df2",
-        "default_to_phone": "+16199804758",
-        "default_from_phone": "+18336913467"
+        "account_sid": "${TWILIO_ACCOUNT_SID}",
+        "auth_token": "${TWILIO_AUTH_TOKEN}",
+        "flow_sid": "${TWILIO_FLOW_SID}",
+        "default_to_phone": "${TWILIO_TO_PHONE}",
+        "default_from_phone": "${TWILIO_FROM_PHONE}"
       }
     },
     "defaults": {
@@ -60,7 +60,7 @@
     },
     "coinmarketcap": {
       "enabled": true,
-      "api_key": "c51c0c22-1bf3-4674-86bf-36f39a912d1a"
+      "api_key": "${COINMARKETCAP_API_KEY}"
     },
     "coinpaprika": {
       "enabled": true

--- a/config/sonic_config.json
+++ b/config/sonic_config.json
@@ -6,7 +6,7 @@
       "SOL"
     ],
     "currency": "USD",
-    "cmc_api_key": "c51c0c22-1bf3-4674-86bf-36f39a912d1a"
+    "cmc_api_key": "${COINMARKETCAP_API_KEY}"
   },
   "system_config": {
     "logging_enabled": true,
@@ -25,15 +25,15 @@
     "coinmarketcap_api_enabled": "ENABLE",
     "coinpaprika_api_enabled": "ENABLE",
     "binance_api_enabled": "ENABLE",
-    "coinmarketcap_api_key": "c51c0c22-1bf3-4674-86bf-36f39a912d1a"
+    "coinmarketcap_api_key": "${COINMARKETCAP_API_KEY}"
   },
   "notification_config": {
     "email": {
-      "smtp_server": "smtp.gmail.com",
-      "smtp_port": 587,
-      "smtp_user": "bubba.diego@gmail.com",
-      "smtp_password": "pzix taan afbe igxb",
-      "recipient_email": "bubba.diego@gmail.com"
+      "smtp_server": "${SMTP_SERVER}",
+      "smtp_port": "${SMTP_PORT}",
+      "smtp_user": "${SMTP_USERNAME}",
+      "smtp_password": "${SMTP_PASSWORD}",
+      "recipient_email": "${SMTP_DEFAULT_RECIPIENT}"
     },
     "sms": {
       "carrier_gateway": "txt.att.net",
@@ -41,11 +41,11 @@
     }
   },
   "twilio_config": {
-    "account_sid": "ACb606788ada5dccbfeeebed0f440099b3",
-    "auth_token": "ca16911e2a3c25f618a634c9fe34e368",
-    "flow_sid": "FW5b3bf49ee04af4d23a118b613bbc0df2",
-    "to_phone": "+16199804758",
-    "from_phone": "+18336913467"
+    "account_sid": "${TWILIO_ACCOUNT_SID}",
+    "auth_token": "${TWILIO_AUTH_TOKEN}",
+    "flow_sid": "${TWILIO_FLOW_SID}",
+    "to_phone": "${TWILIO_TO_PHONE}",
+    "from_phone": "${TWILIO_FROM_PHONE}"
   },
   "theme_config": {
     "selected_profile": "profile4",

--- a/data/com_config.json
+++ b/data/com_config.json
@@ -4,13 +4,13 @@
       "email": {
         "enabled": true,
         "smtp": {
-          "server": "smtp.gmail.com",
-          "port": 587,
-          "username": "bubba.diego@gmail.com",
-          "password": "pzix taan afbe igxb",
-          "default_recipient": "bubba.diego@gmail.com"
+          "server": "${SMTP_SERVER}",
+          "port": "${SMTP_PORT}",
+          "username": "${SMTP_USERNAME}",
+          "password": "${SMTP_PASSWORD}",
+          "default_recipient": "${SMTP_DEFAULT_RECIPIENT}"
         }
-      },     
+      },
       "api_config": {
         "coingecko_api_enabled":    "ENABLE",
         "coinmarketcap_api_enabled":"ENABLE",
@@ -26,11 +26,11 @@
       },
       "twilio": {
         "enabled": true,
-        "account_sid": "ACb606788ada5dccbfeeebed0f440099b3",
-        "auth_token": "4a44ade7492e8aac43cb05342f74c492",
-        "flow_sid": "FW5b3bf49ee04af4d23a118b613bbc0df2",
-        "default_to_phone": "+16199804758",
-        "default_from_phone": "+18336913467"
+        "account_sid": "${TWILIO_ACCOUNT_SID}",
+        "auth_token": "${TWILIO_AUTH_TOKEN}",
+        "flow_sid": "${TWILIO_FLOW_SID}",
+        "default_to_phone": "${TWILIO_TO_PHONE}",
+        "default_from_phone": "${TWILIO_FROM_PHONE}"
       }
     },
     "defaults": {
@@ -60,7 +60,7 @@
     },
     "coinmarketcap": {
       "enabled": true,
-      "api_key": "c51c0c22-1bf3-4674-86bf-36f39a912d1a"
+      "api_key": "${COINMARKETCAP_API_KEY}"
     },
     "coinpaprika": {
       "enabled": true


### PR DESCRIPTION
## Summary
- load smtp/twilio values from env if missing or using placeholders
- reference env vars in default communication configs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*