### PR TITLE
Fix DataLocker circular import

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,18 @@ python -m data.threshold_seeder
 Run it from the project root on Windows or Linux. Existing thresholds will be
 updated to match the defaults defined in the script.
 
+## Running `sonic_app.py`
+
+The Flask dashboard can be started directly from the project root. Ensure that
+all required environment variables above are set (either in a `.env` file or in
+your shell) and then run:
+
+```bash
+python sonic_app.py
+```
+
+By default the server listens on `0.0.0.0:5000`. Open
+`http://127.0.0.1:5000/` in your browser to access the dashboard. Use the
+`--monitor` flag if you want to also launch the local monitor process in a
+separate console.
+

--- a/positions/hedge_manager.py
+++ b/positions/hedge_manager.py
@@ -13,9 +13,12 @@ import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
-from data.data_locker import DataLocker
+# Avoid circular import at runtime; only import DataLocker when type checking or
+# inside methods.
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from data.data_locker import DataLocker
 from data.models import Hedge
 from core.core_imports import DB_PATH
 from hedge_core.hedge_core import HedgeCore
@@ -24,8 +27,11 @@ from hedge_core.hedge_core import HedgeCore
 class HedgeManager:
     """Backwards compatible wrapper around :class:`HedgeCore`."""
 
-    def __init__(self, positions: Optional[List[dict]] = None, data_locker: DataLocker = None):
-        self.dl = data_locker or DataLocker(str(DB_PATH))
+    def __init__(self, positions: Optional[List[dict]] = None, data_locker: "DataLocker" = None):
+        if data_locker is None:
+            from data.data_locker import DataLocker as _DataLocker
+            data_locker = _DataLocker(str(DB_PATH))
+        self.dl = data_locker
         self.core = HedgeCore(self.dl)
         self.positions = positions if positions is not None else []
         self.hedges: List[Hedge] = []
@@ -44,13 +50,15 @@ class HedgeManager:
 
     @staticmethod
     def find_hedges(db_path: str = DB_PATH) -> List[list]:
-        dl = DataLocker(str(db_path))
+        from data.data_locker import DataLocker as _DataLocker
+        dl = _DataLocker(str(db_path))
         core = HedgeCore(dl)
         return core.link_hedges()
 
     @staticmethod
     def clear_hedge_data(db_path: str = DB_PATH) -> None:
-        dl = DataLocker(str(db_path))
+        from data.data_locker import DataLocker as _DataLocker
+        dl = _DataLocker(str(db_path))
         core = HedgeCore(dl)
         core.unlink_hedges()
 


### PR DESCRIPTION
## Summary
- avoid circular import between DataLocker and HedgeManager
- document how to run `sonic_app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*