### PR TITLE
Fix wallet image paths on alert status page

### DIFF
--- a/app/alerts_bp.py
+++ b/app/alerts_bp.py
@@ -199,13 +199,20 @@ def alert_status_page():
             a["asset_image"] = ASSET_IMAGE_MAP.get(asset_key, DEFAULT_ASSET_IMAGE)
 
             meta = resolve_wallet_metadata(SimpleNamespace(**a), dl)
-            wallet_path = meta.get("wallet_image")
-            if wallet_path:
-                wallet_img = os.path.basename(wallet_path)
+            wallet_path = meta.get("wallet_image") or ""
+
+            wallet_name = meta.get("wallet_name")
+            if wallet_name in WALLET_IMAGE_MAP:
+                wallet_img = os.path.join("images", WALLET_IMAGE_MAP[wallet_name])
+            elif wallet_path.startswith("/static/"):
+                wallet_img = wallet_path[len("/static/"):]
+            elif wallet_path:
+                wallet_img = wallet_path.lstrip("/")
             else:
-                wallet_img = DEFAULT_WALLET_IMAGE
-            a["wallet_image"] = WALLET_IMAGE_MAP.get(meta.get("wallet_name"), wallet_img)
-            a["wallet_name"] = meta.get("wallet_name")
+                wallet_img = os.path.join("images", DEFAULT_WALLET_IMAGE)
+
+            a["wallet_image"] = wallet_img
+            a["wallet_name"] = wallet_name
 
             enriched.append(a)
         alerts = enriched

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -57,7 +57,7 @@
               <td class="right">{{ "{:,.2f}".format(alert.trigger_value or 0) }}</td>
               <td class="left">{{ alert.level }}</td>
               <td class="left">{{ alert.status }}</td>
-              <td class="left"><img class="wallet-icon" src="{{ url_for('static', filename='images/' + (alert.wallet_image or alert.asset_image)) }}" alt="{{ alert.wallet_name or alert.asset }}"><span style="display:none">{{ alert.wallet_name or 'N/A' }}</span></td>
+              <td class="left"><img class="wallet-icon" src="{{ url_for('static', filename=alert.wallet_image if alert.wallet_image else 'images/' + alert.asset_image) }}" alt="{{ alert.wallet_name or alert.asset }}"><span style="display:none">{{ alert.wallet_name or 'N/A' }}</span></td>
             </tr>
             {% endfor %}
           {% else %}
@@ -76,7 +76,7 @@
         {% for alert in alerts %}
           {% if alert.travel_percent is defined and alert.travel_percent is not none %}
           <div class="liq-row" data-alert-id="{{ alert.id }}">
-            <img class="wallet-icon" src="{{ url_for('static', filename='images/' + (alert.wallet_image or alert.asset_image)) }}" alt="{{ alert.wallet_name or alert.asset }}" />
+            <img class="wallet-icon" src="{{ url_for('static', filename=alert.wallet_image if alert.wallet_image else 'images/' + alert.asset_image) }}" alt="{{ alert.wallet_name or alert.asset }}" />
             <div class="liq-progress-bar">
               <div class="liq-bar-container">
                 <div class="liq-midline"></div>


### PR DESCRIPTION
## Summary
- ensure wallet path is preserved under `/static` so uploaded images show up
- load wallet image path directly in template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and IndentationError)*