### PR TITLE
Implement portfolio CRUD wrappers

### DIFF
--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -262,6 +262,27 @@ class DataLocker:
         if hasattr(self.positions, "delete_positions_for_wallet"):
             self.positions.delete_positions_for_wallet(wallet_name)
 
+    # ---- Portfolio convenience wrappers ----
+    def get_portfolio_history(self):
+        """Return all portfolio snapshot entries."""
+        return self.portfolio.get_snapshots()
+
+    def add_portfolio_entry(self, entry: dict):
+        """Insert a snapshot entry into the portfolio history."""
+        self.portfolio.add_entry(entry)
+
+    def update_portfolio_entry(self, entry_id: str, fields: dict):
+        """Update a portfolio history entry by its ID."""
+        self.portfolio.update_entry(entry_id, fields)
+
+    def get_portfolio_entry_by_id(self, entry_id: str):
+        """Fetch a portfolio history entry by ID."""
+        return self.portfolio.get_entry_by_id(entry_id)
+
+    def delete_portfolio_entry(self, entry_id: str):
+        """Delete a portfolio history entry."""
+        self.portfolio.delete_entry(entry_id)
+
     def _seed_modifiers_if_empty(self):
         """Seed modifiers table from sonic_sauce.json if empty."""
         cursor = self.db.get_cursor()

--- a/data/dl_portfolio.py
+++ b/data/dl_portfolio.py
@@ -65,3 +65,78 @@ class DLPortfolioManager:
         except Exception as e:
             log.error(f"Failed to fetch latest snapshot: {e}", source="DLPortfolioManager")
             return {}
+    def add_entry(self, entry: dict):
+        """Insert a manual portfolio entry into positions_totals_history."""
+        try:
+            cursor = self.db.get_cursor()
+            if "id" not in entry:
+                entry["id"] = str(uuid4())
+            if "snapshot_time" not in entry:
+                entry["snapshot_time"] = datetime.now().isoformat()
+            cursor.execute(
+                """
+                INSERT INTO positions_totals_history (
+                    id, snapshot_time, total_size, total_value,
+                    total_collateral, avg_leverage, avg_travel_percent, avg_heat_index
+                ) VALUES (:id, :snapshot_time, :total_size, :total_value,
+                          :total_collateral, :avg_leverage, :avg_travel_percent, :avg_heat_index)
+                """,
+                {
+                    "id": entry["id"],
+                    "snapshot_time": entry.get("snapshot_time"),
+                    "total_size": entry.get("total_size", 0.0),
+                    "total_value": entry.get("total_value", 0.0),
+                    "total_collateral": entry.get("total_collateral", 0.0),
+                    "avg_leverage": entry.get("avg_leverage", 0.0),
+                    "avg_travel_percent": entry.get("avg_travel_percent", 0.0),
+                    "avg_heat_index": entry.get("avg_heat_index", 0.0),
+                },
+            )
+            self.db.commit()
+            log.success(f"Portfolio entry added: {entry['id']}", source="DLPortfolioManager")
+        except Exception as e:
+            log.error(f"Failed to add portfolio entry: {e}", source="DLPortfolioManager")
+
+    def update_entry(self, entry_id: str, fields: dict):
+        """Update fields of an existing portfolio entry by id."""
+        try:
+            if not fields:
+                return
+            cursor = self.db.get_cursor()
+            set_clause = ", ".join(f"{k} = ?" for k in fields.keys())
+            params = list(fields.values()) + [entry_id]
+            cursor.execute(
+                f"UPDATE positions_totals_history SET {set_clause} WHERE id = ?",
+                params,
+            )
+            self.db.commit()
+            log.info(f"Portfolio entry updated: {entry_id}", source="DLPortfolioManager")
+        except Exception as e:
+            log.error(f"Failed to update portfolio entry {entry_id}: {e}", source="DLPortfolioManager")
+
+    def get_entry_by_id(self, entry_id: str) -> dict:
+        """Return a portfolio entry by its ID."""
+        try:
+            cursor = self.db.get_cursor()
+            cursor.execute(
+                "SELECT * FROM positions_totals_history WHERE id = ?",
+                (entry_id,),
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+        except Exception as e:
+            log.error(f"Failed to fetch portfolio entry {entry_id}: {e}", source="DLPortfolioManager")
+            return None
+
+    def delete_entry(self, entry_id: str):
+        """Delete a portfolio entry by ID."""
+        try:
+            cursor = self.db.get_cursor()
+            cursor.execute(
+                "DELETE FROM positions_totals_history WHERE id = ?",
+                (entry_id,),
+            )
+            self.db.commit()
+            log.info(f"Portfolio entry deleted: {entry_id}", source="DLPortfolioManager")
+        except Exception as e:
+            log.error(f"Failed to delete portfolio entry {entry_id}: {e}", source="DLPortfolioManager")


### PR DESCRIPTION
## Summary
- extend `DLPortfolioManager` with CRUD methods for positions_totals_history
- add wrapper helpers in `DataLocker` to delegate to the portfolio manager

## Testing
- `pytest -q` *(fails: 40 errors during collection)*