### PR TITLE
Fix handling of corrupted SQLite database

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -20,7 +20,7 @@ class DatabaseManager:
                 self.conn.execute("PRAGMA journal_mode=WAL;")
             except sqlite3.DatabaseError as e:
                 # Handle corruption or non-database files gracefully
-                if "file is not a database" in str(e):
+                if "file is not a database" in str(e) or "database disk image is malformed" in str(e):
                     self.conn.close()
                     # Remove the bad file and recreate a fresh database
                     try:


### PR DESCRIPTION
## Summary
- address scenario where SQLite database reports `database disk image is malformed`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*