### PR TITLE
Add Wallet Manager link

### DIFF
--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -35,6 +35,7 @@
           <li><a class="dropdown-item" href="/system/themes/editor"><span>🎨</span> Theme Builder</a></li>
           <li><a class="dropdown-item" href="/system/database_viewer"><span>🗃️</span> Database Viewer</a></li>
           <li><a class="dropdown-item" href="/system/alert_thresholds"><span>📏</span> Alert Thresholds</a></li>
+          <li><a class="dropdown-item" href="/system/wallets"><span>💼</span> Wallet Manager</a></li>
           <li><a class="dropdown-item" href="/system/xcom_config"><span>🔌</span> XCom Config</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- expose wallet manager from the settings dropdown menu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts', etc.)*