### PR TITLE
Handle plain text wallet keys

### DIFF
--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -63,3 +63,22 @@ def test_create_wallet_encrypted(tmp_path):
     assert row is not None
     assert row[0] != "secret"
     assert decrypt_key(row[0]) == "secret"
+
+
+def test_list_wallet_plaintext_private_key(tmp_path):
+    service = setup_service()
+
+    conn = sqlite3.connect(TEST_DB)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO wallets (name, public_address, private_address, image_path, balance, tags, is_active, type)
+        VALUES (?, ?, ?, ?, ?, '', 1, 'personal')
+        """,
+        ("plain", "0x123", "plaintext", "", 0.0),
+    )
+    conn.commit()
+
+    wallets = service.list_wallets()
+    names = [w.name for w in wallets]
+    assert "plain" in names

--- a/wallets/encryption.py
+++ b/wallets/encryption.py
@@ -1,5 +1,6 @@
 import os
 import base64
+import binascii
 from itertools import cycle
 
 _KEY = os.getenv("WALLET_ENCRYPTION_KEY", "simplekey").encode()
@@ -17,8 +18,13 @@ def encrypt_key(plain: str | None) -> str | None:
 
 
 def decrypt_key(enc: str | None) -> str | None:
+    """Decrypt a value if it appears to be encoded, otherwise return as-is."""
     if enc is None:
         return None
-    data = base64.b64decode(enc)
-    dec = _xor(data)
-    return dec.decode()
+    try:
+        data = base64.b64decode(enc)
+        dec = _xor(data)
+        return dec.decode()
+    except (binascii.Error, ValueError):
+        # Value was not base64-encoded; treat as plain text
+        return enc


### PR DESCRIPTION
## Summary
- handle malformed wallet data that isn't base64 encoded
- add test for reading wallets with plaintext keys

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*