### PR TITLE
Add database initialization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,13 @@ By default the server listens on `0.0.0.0:5000`. Open
 `--monitor` flag if you want to also launch the local monitor process in a
 separate console.
 
+
+## Initializing the Database
+
+To create the SQLite database and all required tables, run:
+
+```bash
+python scripts/init_db.py
+```
+
+The script will create `mother_brain.db` in the `data` directory (or the path set via the `DB_PATH` environment variable) and ensure every table exists.

--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -150,6 +150,18 @@ class DataLocker:
                     pnl_after_fees_usd REAL
                 )
             """,
+            "positions_totals_history": """
+                CREATE TABLE IF NOT EXISTS positions_totals_history (
+                    id TEXT PRIMARY KEY,
+                    snapshot_time TEXT,
+                    total_size REAL,
+                    total_value REAL,
+                    total_collateral REAL,
+                    avg_leverage REAL,
+                    avg_travel_percent REAL,
+                    avg_heat_index REAL
+                )
+            """,
             "modifiers": """
             CREATE TABLE IF NOT EXISTS modifiers (
                 key TEXT PRIMARY KEY,

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Initialize the SQLite database with all required tables.
+
+Running this script will create ``mother_brain.db`` (or the DB_PATH set in the
+``BASE_DIR`` environment) and ensure all tables exist. It simply instantiates
+``DataLocker`` which performs table creation.
+"""
+from __future__ import annotations
+
+from core.core_imports import DB_PATH
+from data.data_locker import DataLocker
+
+
+def main() -> int:
+    locker = DataLocker(str(DB_PATH))
+    locker.close()
+    print(f"✅ Database initialized at: {DB_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/init_db.py` to create all database tables
- document running the init script in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*