### PR TITLE
Fix title bar JS inclusion

### DIFF
--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -50,3 +50,4 @@
   </div>
   </nav>
   <script src="{{ url_for('static', filename='js/refresh_timer.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- load `title_bar.js` in `title_bar.html`

## Testing
- `pytest -q` *(fails: 40 errors during collection)*