### PR TITLE
Add HedgeCalcServices spec

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -25,6 +25,7 @@ The [Calculation Core module](calc_core/calculation_module_spec.md) houses risk 
 
 ### Hedge Core
 The [Hedge Core module](hedge_core/hedge_core_module_spec.md) links long and short positions into hedge groups and aggregates their metrics.
+The [HedgeCalcServices specification](hedge_core/hedge_calc_services_spec.md) details calculations for dynamic hedging and rebalance suggestions.
 
 ### Monitor Core
 The [Monitor module](monitor/monitor_module_spec.md) drives periodic tasks and health checks. It registers individual monitors and exposes CLI and API entrypoints for running them.

--- a/hedge_core/hedge_calc_services_spec.md
+++ b/hedge_core/hedge_calc_services_spec.md
@@ -1,0 +1,72 @@
+# 📐 HedgeCalcServices Specification
+
+> Version: `v1.0`
+> Author: `CoreOps 🥷`
+> Scope: Delta and gamma hedging calculations for opposing positions.
+
+`HedgeCalcServices` is a calculation utility supporting delta and gamma hedging workflows. It evaluates paired long and short positions, measures imbalance, and suggests rebalancing actions.
+
+---
+
+## 🎯 Goals
+- Simulate value, PnL, and imbalance at any price.
+- Suggest rebalances by adjusting `size`, `collateral`, or `leverage`.
+- Enable delta/gamma hedging via exposure modeling.
+- Allow user configurable strategies and constraints.
+
+## 📦 Inputs
+
+### Position Object
+```json
+{
+  "id": "uuid",
+  "position_type": "LONG" | "SHORT",
+  "entry_price": float,
+  "size": float,
+  "collateral": float,
+  "leverage": float,
+  "liquidation_price": float
+}
+```
+
+### Hedge Pair Input
+```python
+(long_position: dict, short_position: dict, price: float, config: dict)
+```
+
+### Config Example
+```json
+{
+  "adjustment_target": "equal_value",
+  "adjustable_side": "long",
+  "adjust_fields": ["size", "collateral"]
+}
+```
+
+## 🛠️ Core Methods
+
+### 1. `evaluate_at_price(long_pos, short_pos, price) -> dict`
+Returns evaluation details for both positions at the supplied price.
+
+### 2. `suggest_rebalance(long_pos, short_pos, price, config) -> dict`
+Proposes how to rebalance the selected side to meet a target strategy.
+Supported targets:
+- `equal_value` – equalize the value at the current price.
+- `delta_neutral` – adjust to make combined delta ~0.
+- `gamma_flat` – match gamma exposures (optional).
+
+### 3. `simulate_range(long_pos, short_pos, price_range) -> list[dict]`
+Evaluates the pair across a set of prices for graphing and UI sliders.
+
+## 🧪 Testing Strategy
+- Unit tests for known PnL and value outputs.
+- Rebalance suggestions where the imbalance is clear.
+
+## 🧠 Future Expansion
+- Support multiple position groups.
+- Historical backtesting of strategies.
+- Deeper derivative modeling for delta/gamma calculations.
+
+## 📎 Notes
+- This service is purely mathematical—no DB operations.
+- All values are floats rounded to 6 decimals unless configured.


### PR DESCRIPTION
## Summary
- describe HedgeCalcServices for dynamic hedging logic
- reference the new spec from the specification index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*