### PR TITLE
Add DB seeding helper

### DIFF
--- a/data/seed_database.py
+++ b/data/seed_database.py
@@ -1,0 +1,34 @@
+"""Seed default data into the SQLite database.
+
+This script ensures the database schema is initialized and then
+inserts the default alert thresholds defined in :mod:`data.threshold_seeder`.
+Run from the project root:
+
+    python -m data.seed_database
+"""
+
+import os
+import sys
+
+# Allow running this file directly.
+if __name__ == "__main__" and __package__ is None:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
+from data.data_locker import DataLocker
+from data.threshold_seeder import AlertThresholdSeeder
+
+
+def seed_database():
+    """Bootstrap database tables and seed default alert thresholds."""
+    configure_console_log()
+    dl = DataLocker(str(DB_PATH))
+    seeder = AlertThresholdSeeder(dl.db)
+    created, updated = seeder.seed_all()
+    print(f"✅ Seed complete → {created} created, {updated} updated.")
+    dl.close()
+
+
+if __name__ == "__main__":
+    seed_database()


### PR DESCRIPTION
## Summary
- add `seed_database.py` helper in `data` for initializing DB tables and running the threshold seeder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: rich)*