### PR TITLE
Fix hedging imports and add price evaluation helpers

### DIFF
--- a/cyclone/cyclone_console/commands/hedge.py
+++ b/cyclone/cyclone_console/commands/hedge.py
@@ -5,7 +5,8 @@ from rich.console import Console
 from rich.table import Table
 from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
-from sonic_labs.hedge_manager import HedgeManager
+# HedgeManager lives under positions. Import it from there so the CLI works.
+from positions.hedge_manager import HedgeManager
 from cyclone.cyclone_hedge_service import CycloneHedgeService
 
 app = typer.Typer(help="🛡 Hedge detection and management")

--- a/cyclone/cyclone_console/cyclone_console_service.py
+++ b/cyclone/cyclone_console/cyclone_console_service.py
@@ -2,7 +2,8 @@ import asyncio
 import os
 from cyclone_engine import Cyclone
 from data.data_locker import DataLocker
-from sonic_labs.hedge_manager import HedgeManager
+# Import HedgeManager from the actual implementation location
+from positions.hedge_manager import HedgeManager
 from core.logging import log
 from cyclone.cyclone_position_service import CyclonePositionService
 from cyclone.cyclone_portfolio_service import CyclonePortfolioService

--- a/data/dl_positions.py
+++ b/data/dl_positions.py
@@ -16,7 +16,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from uuid import uuid4
 from datetime import datetime
 from core.core_imports import log
-import winsound
 
 
 class DLPositionManager:

--- a/tests/test_calc_services_at_price.py
+++ b/tests/test_calc_services_at_price.py
@@ -1,0 +1,34 @@
+import pytest
+from calc_core.calc_services import CalcServices
+
+@pytest.fixture
+def sample_position():
+    return {
+        "position_type": "LONG",
+        "entry_price": 100.0,
+        "liquidation_price": 50.0,
+        # Size represents token amount. Entry price is 100, so position value at
+        # entry is 200 and leverage matches collateral below.
+        "size": 2.0,
+        "collateral": 100.0,
+        "leverage": 2.0,
+    }
+
+def test_price_metric_functions(sample_position):
+    calc = CalcServices()
+    price = 90.0
+    assert calc.value_at_price(sample_position, price) == pytest.approx(180.0)
+    assert calc.travel_percent_at_price(sample_position, price) == pytest.approx(-20.0)
+    assert calc.liquid_distance_at_price(sample_position, price) == 40.0
+    # Collateral is high relative to size so risk floor of 5 applies
+    assert calc.heat_index_at_price(sample_position, price) == pytest.approx(5.0)
+
+def test_evaluate_at_price(sample_position):
+    calc = CalcServices()
+    price = 120.0
+    result = calc.evaluate_at_price(sample_position, price)
+    assert result["value"] == pytest.approx(240.0)
+    assert result["travel_percent"] == pytest.approx(40.0)
+    assert result["liquidation_distance"] == 70.0
+    assert result["heat_index"] == pytest.approx(5.0)
+


### PR DESCRIPTION
## Summary
- point console hedge imports at the real HedgeManager
- drop unused winsound import
- add helper functions to CalcServices for evaluating a position at a given price
- test the new evaluation helpers

## Testing
- `pytest tests/test_calc_services_at_price.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*