### PR TITLE
Fix portfolio history formatting

### DIFF
--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -133,24 +133,9 @@ def get_alert_icon(alert_type):
 @route_log_alert
 def api_graph_data():
     """Return portfolio snapshot totals for the history line chart."""
-    dl = current_app.data_locker
-    portfolio_history = dl.portfolio.get_snapshots() or []
-
-    timestamps = []
-    values = []
-    collateral = []
-
-    # Collect the actual totals from each snapshot without accumulating
-    for entry in portfolio_history:
-        timestamps.append(entry.get("snapshot_time"))
-        values.append(float(entry.get("total_value", 0)))
-        collateral.append(float(entry.get("total_collateral", 0)))
-
-    return jsonify({
-        "timestamps": timestamps,
-        "values": values,
-        "collateral": collateral,
-    })
+    context = get_dashboard_context(current_app.data_locker)
+    graph = context.get("graph_data", {})
+    return jsonify(graph)
 
 # ---------------------------------
 # API: Size Composition Pie (Real positions)

--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -251,8 +251,18 @@ def get_dashboard_context(data_locker):
 
     for snap in snapshots:
         timestamps.append(snap.get("snapshot_time"))
-        values.append(float(snap.get("total_value", 0)))
-        collateral.append(float(snap.get("total_collateral", 0)))
+        values.append(int(round(float(snap.get("total_value", 0)))) )
+        collateral.append(int(round(float(snap.get("total_collateral", 0)))) )
+
+    current_value_int = int(round(totals["total_value"]))
+    if values:
+        if values[-1] != current_value_int:
+            values[-1] = current_value_int
+
+    current_collateral_int = int(round(totals["total_collateral"]))
+    if collateral:
+        if collateral[-1] != current_collateral_int:
+            collateral[-1] = current_collateral_int
 
     graph_data = {
         "timestamps": timestamps,

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -40,6 +40,11 @@ function renderGraph(data) {
       categories: data.timestamps,
       labels: { show: false }
     },
+    yaxis: {
+      labels: {
+        formatter: val => Math.round(val)
+      }
+    },
     colors: ["#3498db", "#2ecc71"],
     grid: { borderColor: "#444" },
     stroke: { curve: "smooth" },

--- a/static/js/dashboard_bottom.js
+++ b/static/js/dashboard_bottom.js
@@ -25,6 +25,11 @@ function renderLineChart(data) {
       type: 'datetime',
       categories: data.timestamps
     },
+    yaxis: {
+      labels: {
+        formatter: val => Math.round(val)
+      }
+    },
     colors: ['#2980b9', '#27ae60'],
     stroke: { curve: 'smooth' },
     tooltip: { x: { format: 'yyyy-MM-dd HH:mm' } }


### PR DESCRIPTION
## Summary
- ensure graph data uses whole numbers
- keep final graph point in sync with latest totals
- adjust dashboard bottom API to reuse context
- display whole numbers on dashboard charts

## Testing
- `pytest -q` *(fails: 40 errors during collection)*