### PR TITLE
Add Hedge Labs page and nav link

### DIFF
--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -1,7 +1,7 @@
 
 # sonic_labs_bp.py
 
-from flask import Blueprint, jsonify, current_app, request
+from flask import Blueprint, jsonify, current_app, request, render_template
 import json
 from positions.position_sync_service import PositionSyncService  # noqa: F401
 from positions.position_core_service import PositionCoreService  # noqa: F401
@@ -42,4 +42,83 @@ def update_sonic_sauce():
         return jsonify({"success": True}), 200
     except Exception as e:
         current_app.logger.error(f"Error saving sonic sauce: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+@sonic_labs_bp.route("/hedge_labs", methods=["GET"])
+@retry_on_locked()
+def hedge_labs_page():
+    """Render the Hedge Labs UI."""
+    dl = current_app.data_locker
+    hedges = dl.hedges.get_hedges() or []
+    theme_config = dl.system.get_active_theme_profile() or {}
+    return render_template(
+        "hedge_labs.html",
+        hedges=hedges,
+        theme=theme_config,
+    )
+
+
+@sonic_labs_bp.route("/api/hedges", methods=["GET"])
+@retry_on_locked()
+def api_get_hedges():
+    """Return current hedges as JSON."""
+    hedges = current_app.data_locker.hedges.get_hedges() or []
+    data = [
+        {
+            "id": h.id,
+            "positions": h.positions,
+            "total_long_size": h.total_long_size,
+            "total_short_size": h.total_short_size,
+            "total_heat_index": h.total_heat_index,
+        }
+        for h in hedges
+    ]
+    return jsonify({"hedges": data})
+
+
+@sonic_labs_bp.route("/api/link_hedges", methods=["POST"])
+@retry_on_locked()
+def api_link_hedges():
+    """Link hedges using HedgeCore."""
+    try:
+        from hedge_core.hedge_core import HedgeCore
+
+        core = HedgeCore(current_app.data_locker)
+        groups = core.link_hedges()
+        return jsonify({"linked": len(groups)})
+    except Exception as e:
+        current_app.logger.error(f"Error linking hedges: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+@sonic_labs_bp.route("/api/unlink_hedges", methods=["POST"])
+@retry_on_locked()
+def api_unlink_hedges():
+    """Unlink all hedges."""
+    try:
+        from hedge_core.hedge_core import HedgeCore
+
+        core = HedgeCore(current_app.data_locker)
+        core.unlink_hedges()
+        return jsonify({"unlinked": True})
+    except Exception as e:
+        current_app.logger.error(f"Error unlinking hedges: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+@sonic_labs_bp.route("/api/test_calcs", methods=["GET"])
+@retry_on_locked()
+def api_test_calcs():
+    """Run basic calculation tests and return results."""
+    try:
+        from calc_core.calculation_core import CalculationCore
+
+        dl = current_app.data_locker
+        positions = dl.positions.get_all_positions() or []
+        core = CalculationCore(dl)
+        totals = core.calculate_totals(positions)
+        return jsonify({"totals": totals})
+    except Exception as e:
+        current_app.logger.error(f"Error running test calcs: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500

--- a/static/js/hedge_labs.js
+++ b/static/js/hedge_labs.js
@@ -1,0 +1,34 @@
+function loadHedges() {
+  fetch('/sonic_labs/api/hedges')
+    .then(resp => resp.json())
+    .then(data => {
+      const tbody = document.getElementById('hedgeTableBody');
+      if (!tbody) return;
+      tbody.innerHTML = '';
+      (data.hedges || []).forEach(h => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${h.id}</td><td>${h.positions.join(', ')}</td><td>${h.total_heat_index}</td>`;
+        tbody.appendChild(tr);
+      });
+    });
+}
+
+function postAction(url) {
+  fetch(url, {method: 'POST'})
+    .then(resp => resp.json())
+    .then(() => loadHedges());
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadHedges();
+  const linkBtn = document.getElementById('linkHedgesBtn');
+  const unlinkBtn = document.getElementById('unlinkHedgesBtn');
+  const testBtn = document.getElementById('testCalcsBtn');
+  if (linkBtn) linkBtn.addEventListener('click', () => postAction('/sonic_labs/api/link_hedges'));
+  if (unlinkBtn) unlinkBtn.addEventListener('click', () => postAction('/sonic_labs/api/unlink_hedges'));
+  if (testBtn) testBtn.addEventListener('click', () => {
+    fetch('/sonic_labs/api/test_calcs').then(resp => resp.json()).then(res => {
+      console.log('Calc Totals', res);
+    });
+  });
+});

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Hedge Labs{% endblock %}
+
+{% block extra_styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+{% endblock %}
+
+{% block content %}
+{% include "title_bar.html" %}
+<div class="container-fluid p-3">
+  <h3 class="mb-3">🧪 Hedge Labs</h3>
+  <div class="mb-3">
+    <button id="linkHedgesBtn" class="btn btn-primary btn-sm me-2">Link Hedges</button>
+    <button id="unlinkHedgesBtn" class="btn btn-secondary btn-sm me-2">Unlink Hedges</button>
+    <button id="testCalcsBtn" class="btn btn-info btn-sm">Test Calcs</button>
+  </div>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Positions</th>
+        <th>Total Heat</th>
+      </tr>
+    </thead>
+    <tbody id="hedgeTableBody">
+      {% for h in hedges %}
+      <tr>
+        <td>{{ h.id }}</td>
+        <td>{{ h.positions|join(', ') }}</td>
+        <td>{{ h.total_heat_index }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/hedge_labs.js') }}"></script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+{% endblock %}

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -4,6 +4,7 @@
     <a class="btn btn-light nav-icon-btn" href="/" title="Home"><span>🏠</span></a>
     <a class="btn btn-light nav-icon-btn" href="/positions" title="Positions"><span>📊</span></a>
     <a class="btn btn-light nav-icon-btn" href="/hedge_calculator" title="Hedge Calculator"><span>🌿</span></a>
+    <a class="btn btn-light nav-icon-btn" href="/sonic_labs/hedge_labs" title="Hedge Labs"><span>🧪</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/alert_thresholds" title="Alert Limits"><span>🚨</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/status_page" title="Alert Status"><span>🎛️</span></a>
     <a class="btn btn-light nav-icon-btn" href="/system/xcom_config" title="XCom Config"><span>🔌</span></a>


### PR DESCRIPTION
## Summary
- add Hedge Labs page with basic hedge management actions
- expose API endpoints on `sonic_labs_bp`
- add Hedge Labs icon link to the title bar
- include JS helpers for Hedge Labs page

## Testing
- `pytest tests/test_hedge_core_linking.py::test_link_hedges_assigns_same_id_for_long_and_short -q`
- `pytest tests/test_hedge_core_unlink.py::test_unlink_hedges_clears_ids -q`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*