### PR TITLE
Add alert thresholds management page

### DIFF
--- a/static/js/alert_thresholds.js
+++ b/static/js/alert_thresholds.js
@@ -1,0 +1,37 @@
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.save-threshold').forEach(btn => {
+    btn.addEventListener('click', async evt => {
+      evt.preventDefault();
+      const row = btn.closest('tr');
+      const id = row.dataset.id;
+      const payload = {
+        low: parseFloat(row.querySelector('[name="low"]').value) || 0,
+        medium: parseFloat(row.querySelector('[name="medium"]').value) || 0,
+        high: parseFloat(row.querySelector('[name="high"]').value) || 0,
+        enabled: row.querySelector('[name="enabled"]').checked,
+        low_notify: Array.from(row.querySelectorAll('[name="low_notify"]:checked')).map(el => el.value),
+        medium_notify: Array.from(row.querySelectorAll('[name="medium_notify"]:checked')).map(el => el.value),
+        high_notify: Array.from(row.querySelectorAll('[name="high_notify"]:checked')).map(el => el.value)
+      };
+      try {
+        const resp = await fetch(`/system/alert_thresholds/update/${id}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (resp.ok) {
+          btn.classList.remove('btn-primary');
+          btn.classList.add('btn-success');
+          setTimeout(() => {
+            btn.classList.remove('btn-success');
+            btn.classList.add('btn-primary');
+          }, 1000);
+        } else {
+          alert('Failed to save threshold');
+        }
+      } catch (err) {
+        alert('Error saving threshold');
+      }
+    });
+  });
+});

--- a/templates/system/alert_thresholds.html
+++ b/templates/system/alert_thresholds.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %}
+
+{% block title %}Alert Thresholds{% endblock %}
+
+{% block extra_styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+{% endblock %}
+
+{% block content %}
+{% include "title_bar.html" %}
+<div class="container-fluid pt-4">
+  <h2 class="mb-4"><i class="fas fa-ruler me-2"></i>Alert Thresholds</h2>
+
+  {% for alert_class, items in grouped_thresholds.items() %}
+  <div class="card mb-4">
+    <div class="card-header bg-secondary text-white">
+      {{ alert_class }}
+    </div>
+    <div class="card-body table-responsive">
+      <table class="table table-sm align-middle">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Metric</th>
+            <th>Condition</th>
+            <th>Low</th>
+            <th>Medium</th>
+            <th>High</th>
+            <th>Enabled</th>
+            <th>Notify (Low)</th>
+            <th>Notify (Med)</th>
+            <th>Notify (High)</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for t in items %}
+          <tr data-id="{{ t.id }}">
+            <td>{{ t.alert_type }}</td>
+            <td>{{ t.metric_key }}</td>
+            <td>{{ t.condition }}</td>
+            <td><input type="number" class="form-control form-control-sm" name="low" value="{{ t.low_val }}"></td>
+            <td><input type="number" class="form-control form-control-sm" name="medium" value="{{ t.medium_val }}"></td>
+            <td><input type="number" class="form-control form-control-sm" name="high" value="{{ t.high_val }}"></td>
+            <td class="text-center"><input type="checkbox" name="enabled" {% if t.enabled %}checked{% endif %}></td>
+            <td>
+              {% for opt in ['Email','SMS','Voice'] %}
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="low_notify" value="{{ opt }}" {% if opt in t.low_notify_list %}checked{% endif %}>
+                <label class="form-check-label small">{{ opt[0] }}</label>
+              </div>
+              {% endfor %}
+            </td>
+            <td>
+              {% for opt in ['Email','SMS','Voice'] %}
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="medium_notify" value="{{ opt }}" {% if opt in t.medium_notify_list %}checked{% endif %}>
+                <label class="form-check-label small">{{ opt[0] }}</label>
+              </div>
+              {% endfor %}
+            </td>
+            <td>
+              {% for opt in ['Email','SMS','Voice'] %}
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" name="high_notify" value="{{ opt }}" {% if opt in t.high_notify_list %}checked{% endif %}>
+                <label class="form-check-label small">{{ opt[0] }}</label>
+              </div>
+              {% endfor %}
+            </td>
+            <td><button class="btn btn-sm btn-primary save-threshold">Save</button></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/alert_thresholds.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a new template to manage alert thresholds
- include JS helper for updating thresholds via AJAX

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*