### PR TITLE
Update title bar layout

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -72,6 +72,18 @@
   color: #7c3aed;
   border-color: #7c3aed;
 }
+.config-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #cce5ff;
+  border-radius: 50px;
+  box-shadow: inset 0 0 5px #ffa726;
+  padding: 0.11rem 1.25rem;
+  width: fit-content;
+  margin: auto;
+  gap: 0.5rem;
+}
 .cyclone-bar {
   display: flex;
   justify-content: center;

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -21,35 +21,34 @@
     <span class="profit-badge badge text-bg-success ms-2">{{ profit_badge_value }}</span>
     {% endif %}
   </div>
-    <div class="title-bar-actions d-flex align-items-center gap-3">
-      <div class="config-bar d-flex align-items-center gap-2">
-        <a id="layoutModeToggle" class="btn btn-outline-primary nav-icon-btn layout-toggle-btn" href="#" role="button" title="Switch View Mode">
-          🛠 <span id="currentLayoutMode">wide</span>
-        </a>
-        <div class="theme-toggle-group" id="themeToggleGroup">
-          <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
-          <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
-          <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
-        </div>
-        <div class="dropdown ms-2">
-          <a class="btn btn-light nav-icon-btn dropdown-toggle" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">
-            <span>⚙️</span>
-          </a>
-        <ul class="dropdown-menu" aria-labelledby="settingsDropdown">
-          <li><a class="dropdown-item" href="/system/themes/editor"><span>🎨</span> Theme Builder</a></li>
-          <li><a class="dropdown-item" href="/system/database_viewer"><span>🗃️</span> Database Viewer</a></li>
-          <li><a class="dropdown-item" href="/system/alert_thresholds"><span>📏</span> Alert Thresholds</a></li>
-          <li><a class="dropdown-item" href="/system/wallets"><span>💼</span> Wallet Manager</a></li>
-          <li><a class="dropdown-item" href="/system/xcom_config"><span>🔌</span> XCom Config</a></li>
-        </ul>
+  <div class="title-bar-actions d-flex align-items-center gap-3 ms-auto">
+    <div class="config-bar d-flex align-items-center gap-2">
+      <a id="layoutModeToggle" class="btn btn-outline-primary nav-icon-btn layout-toggle-btn" href="#" role="button" title="Switch View Mode">
+        🛠 <span id="currentLayoutMode">wide</span>
+      </a>
+      <div class="theme-toggle-group" id="themeToggleGroup">
+        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
+        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
+        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
       </div>
-      </div>
-      <div class="cyclone-bar d-flex align-items-center gap-2 ms-3">
+    </div>
+    <div class="cyclone-bar d-flex align-items-center gap-2 ms-3">
         <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="sync"   title="Jupiter Sync"><span>🪐</span></a>
         <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="market" title="Market Update"><span>💲</span></a>
         <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="full"  title="Full Cycle"><span>🌪️</span></a>
         <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="wipe"  title="Wipe All"><span>🗑️</span></a>
       </div>
+    <div class="dropdown ms-3">
+      <a class="btn btn-light nav-icon-btn dropdown-toggle" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">
+        <span>⚙️</span>
+      </a>
+      <ul class="dropdown-menu" aria-labelledby="settingsDropdown">
+        <li><a class="dropdown-item" href="/system/themes/editor"><span>🎨</span> Theme Builder</a></li>
+        <li><a class="dropdown-item" href="/system/database_viewer"><span>🗃️</span> Database Viewer</a></li>
+        <li><a class="dropdown-item" href="/system/alert_thresholds"><span>📏</span> Alert Thresholds</a></li>
+        <li><a class="dropdown-item" href="/system/wallets"><span>💼</span> Wallet Manager</a></li>
+        <li><a class="dropdown-item" href="/system/xcom_config"><span>🔌</span> XCom Config</a></li>
+      </ul>
     </div>
   </div>
   </nav>


### PR DESCRIPTION
## Summary
- style the title bar actions so the layout toggle and theme buttons live in a pill container
- move settings dropdown to the far right of the title bar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*