### PR TITLE
Update layout mode toggle icon and styling

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -115,6 +115,31 @@
   transform: scale(1.15);
 }
 
+.config-btn {
+  font-size: 1.2rem;
+  min-width: 27px;
+  min-height: 27px;
+  padding: 0.22rem 0.32rem;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.config-btn:hover {
+  background: transparent;
+  color: inherit;
+  border-color: transparent;
+  box-shadow: none;
+  transform: scale(1.15);
+}
+
+.config-btn.theme-btn {
+  border: none !important;
+  background: transparent !important;
+}
+
 /* Refresh Dial */
 .refresh-dial {
   position: relative;

--- a/static/js/layout_mode.js
+++ b/static/js/layout_mode.js
@@ -1,12 +1,13 @@
 // Layout mode toggle script
 console.log('layout_mode.js loaded');
 const LAYOUT_MODES = ['wide-mode', 'fitted-mode', 'mobile-mode'];
+const LAYOUT_ICONS = ['🖥️', '💻', '📱'];
 let layoutCurrent = 0;
 function setLayoutMode(idx) {
   document.body.classList.remove(...LAYOUT_MODES);
   document.body.classList.add(LAYOUT_MODES[idx]);
-  const label = document.getElementById('currentLayoutMode');
-  if (label) label.innerText = LAYOUT_MODES[idx].replace('-mode', '');
+  const icon = document.getElementById('currentLayoutIcon');
+  if (icon) icon.innerText = LAYOUT_ICONS[idx];
   localStorage.setItem('sonicLayoutMode', idx);
 }
 document.addEventListener('DOMContentLoaded', function() {

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -23,13 +23,13 @@
   </div>
   <div class="title-bar-actions d-flex align-items-center gap-3 ms-auto">
     <div class="config-bar d-flex align-items-center gap-2">
-      <a id="layoutModeToggle" class="btn btn-outline-primary nav-icon-btn layout-toggle-btn" href="#" role="button" title="Switch View Mode">
-        🛠 <span id="currentLayoutMode">wide</span>
+      <a id="layoutModeToggle" class="btn config-btn" href="#" role="button" title="Switch View Mode">
+        <span id="currentLayoutIcon">🖥️</span>
       </a>
       <div class="theme-toggle-group" id="themeToggleGroup">
-        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
-        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
-        <a class="btn btn-outline-secondary nav-icon-btn theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
+        <a class="btn config-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
+        <a class="btn config-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
+        <a class="btn config-btn theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
       </div>
     </div>
     <div class="cyclone-bar d-flex align-items-center gap-2 ms-3">


### PR DESCRIPTION
## Summary
- use pill-style icon container for layout mode
- replace text label with icons for wide, fitted, and mobile
- style config icons like cyclone buttons

## Testing
- `pytest -q` *(fails: 40 errors during collection)*