### PR TITLE
Implement layout display mode buttons

### DIFF
--- a/static/css/sonic_themes.css
+++ b/static/css/sonic_themes.css
@@ -244,7 +244,7 @@ body {
   border-radius: 1rem;
 }
 
-.layout-toggle-btn,
+.layout-btn,
 .theme-btn.active {
   border-color: var(--primary) !important;
   background: var(--primary) !important;
@@ -256,14 +256,14 @@ body {
 }
 
 .theme-btn:hover,
-.layout-toggle-btn:hover {
+.layout-btn:hover {
   background: var(--accent) !important;
   color: var(--text) !important;
 }
 
 .sonic-content-panel,
 .title-bar,
-.layout-toggle-btn,
+.layout-btn,
 .theme-btn {
   transition: background 0.22s, color 0.22s, border-color 0.22s;
 }

--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -36,11 +36,38 @@
   color: #7c3aed;
   border-color: #bcb4ef;
 }
-.layout-toggle-btn {
-  border-radius: 10px;
+.layout-toggle-group {
+  display: inline-flex;
+  gap: 0.22rem;
+  vertical-align: middle;
+}
+
+.layout-btn {
   border: 1.5px solid #d2cdf7;
-  font-size: 1.6rem;          /* 🔍 Larger toggle icon */
+  border-radius: 10px;
   padding: 0.18rem 0.55rem;
+  font-size: 1.6rem;
+  background: #fff;
+  color: #444;
+  cursor: pointer;
+  min-width: 48px;
+  min-height: 48px;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+  outline: none;
+}
+
+.layout-btn.active,
+.layout-btn:focus {
+  background: #7c3aed;
+  color: #fff;
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 2px #e4ddff;
+}
+
+.layout-btn:hover {
+  background: #f2e8fd;
+  color: #7c3aed;
+  border-color: #7c3aed;
 }
 .theme-toggle-group {
   display: inline-flex;

--- a/static/js/layout_mode.js
+++ b/static/js/layout_mode.js
@@ -1,23 +1,30 @@
 // Layout mode toggle script
 console.log('layout_mode.js loaded');
 const LAYOUT_MODES = ['wide-mode', 'fitted-mode', 'mobile-mode'];
-const LAYOUT_ICONS = ['🖥️', '💻', '📱'];
-let layoutCurrent = 0;
-function setLayoutMode(idx) {
+
+function setLayoutMode(mode) {
   document.body.classList.remove(...LAYOUT_MODES);
-  document.body.classList.add(LAYOUT_MODES[idx]);
-  const icon = document.getElementById('currentLayoutIcon');
-  if (icon) icon.innerText = LAYOUT_ICONS[idx];
-  localStorage.setItem('sonicLayoutMode', idx);
+  document.body.classList.add(mode);
+
+  const buttons = document.querySelectorAll('.layout-btn[data-mode]');
+  buttons.forEach(btn => {
+    btn.classList.toggle('active', btn.getAttribute('data-mode') === mode);
+  });
+
+  localStorage.setItem('sonicLayoutMode', mode);
 }
-document.addEventListener('DOMContentLoaded', function() {
-  const btn = document.getElementById('layoutModeToggle');
-  layoutCurrent = Number(localStorage.getItem('sonicLayoutMode')) || 0;
-  setLayoutMode(layoutCurrent);
-  if (btn) {
-    btn.addEventListener('click', function() {
-      layoutCurrent = (layoutCurrent + 1) % LAYOUT_MODES.length;
-      setLayoutMode(layoutCurrent);
+
+document.addEventListener('DOMContentLoaded', () => {
+  const buttons = document.querySelectorAll('.layout-btn[data-mode]');
+  let mode = localStorage.getItem('sonicLayoutMode') || LAYOUT_MODES[0];
+  if (!LAYOUT_MODES.includes(mode)) mode = LAYOUT_MODES[0];
+  setLayoutMode(mode);
+
+  buttons.forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      const mode = btn.getAttribute('data-mode');
+      setLayoutMode(mode);
     });
-  }
+  });
 });

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -23,9 +23,11 @@
   </div>
   <div class="title-bar-actions d-flex align-items-center gap-3 ms-auto">
     <div class="config-bar d-flex align-items-center gap-2">
-      <a id="layoutModeToggle" class="btn config-btn" href="#" role="button" title="Switch View Mode">
-        <span id="currentLayoutIcon">🖥️</span>
-      </a>
+      <div class="layout-toggle-group" id="layoutToggleGroup">
+        <a class="btn config-btn layout-btn" href="#" role="button" data-mode="wide-mode" title="Wide Mode">🖥️</a>
+        <a class="btn config-btn layout-btn" href="#" role="button" data-mode="fitted-mode" title="Fitted Mode">💻</a>
+        <a class="btn config-btn layout-btn" href="#" role="button" data-mode="mobile-mode" title="Mobile Mode">📱</a>
+      </div>
       <div class="theme-toggle-group" id="themeToggleGroup">
         <a class="btn config-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
         <a class="btn config-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>


### PR DESCRIPTION
## Summary
- switch layout mode toggle to a group of buttons
- highlight the active display mode like theme buttons
- update JS and CSS for new layout buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*