### PR TITLE
Implement single layout and theme toggles

### DIFF
--- a/static/js/sonic_theme_toggle.js
+++ b/static/js/sonic_theme_toggle.js
@@ -1,53 +1,29 @@
 // == SONIC THEME TOGGLE LOGIC ==
 
 const THEME_KEY = "themeMode";
+const THEMES = ["light", "dark", "funky"];
+const THEME_ICONS = ["☀️", "🌙", "🎨"];
+let themeIndex = 0;
 
-// Sets the theme on <html> and persists to localStorage & cookie
-function setTheme(mode) {
+function applyTheme(idx) {
+  const mode = THEMES[idx];
   document.documentElement.setAttribute("data-theme", mode);
   localStorage.setItem(THEME_KEY, mode);
   document.cookie = THEME_KEY + "=" + mode + ";path=/;max-age=31536000";
+  const icon = document.getElementById('currentThemeIcon');
+  if (icon) icon.innerText = THEME_ICONS[idx];
 }
 
-// Reads persisted theme
-function getPersistedTheme() {
-  let mode = localStorage.getItem(THEME_KEY);
-  if (!mode) {
-    const cookie = document.cookie.split('; ').find(r => r.startsWith(THEME_KEY + '='));
-    if (cookie) mode = cookie.split('=')[1];
-  }
-  return mode || "light";
-}
-
-// Activates the clicked button
-function bindThemeButtons() {
-  const buttons = document.querySelectorAll('.theme-btn[data-theme]');
-  buttons.forEach(btn => {
-    btn.addEventListener('click', e => {
-      const mode = btn.getAttribute('data-theme');
-      setTheme(mode);
-
-      // Update visual active state
-      buttons.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-    });
-  });
-}
-
-// On load, set theme from storage/cookie and highlight correct button
 document.addEventListener("DOMContentLoaded", () => {
-  const mode = getPersistedTheme();
-  setTheme(mode);
-
-  // Set button state
-  const buttons = document.querySelectorAll('.theme-btn[data-theme]');
-  buttons.forEach(btn => {
-    if (btn.getAttribute('data-theme') === mode) {
-      btn.classList.add('active');
-    } else {
-      btn.classList.remove('active');
-    }
-  });
-
-  bindThemeButtons();
+  const btn = document.getElementById('themeModeToggle');
+  const persisted = localStorage.getItem(THEME_KEY) || "light";
+  themeIndex = THEMES.indexOf(persisted);
+  if (themeIndex === -1) themeIndex = 0;
+  applyTheme(themeIndex);
+  if (btn) {
+    btn.addEventListener('click', () => {
+      themeIndex = (themeIndex + 1) % THEMES.length;
+      applyTheme(themeIndex);
+    });
+  }
 });

--- a/static/js/title_bar.js
+++ b/static/js/title_bar.js
@@ -71,24 +71,29 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  // ========== Theme Toggle (3-way) ==========
-  const THEMES = ["light", "dark", "funky"];
-  function setTheme(theme) {
-    if (theme === "light") {
-      document.body.removeAttribute("data-theme");
+  // ========== Theme Toggle (cyclic) ==========
+  const THEMES = ['light', 'dark', 'funky'];
+  const THEME_ICONS = ['☀️', '🌙', '🎨'];
+  let themeIndex = 0;
+  function applyTheme(idx) {
+    const theme = THEMES[idx];
+    if (theme === 'light') {
+      document.body.removeAttribute('data-theme');
     } else {
-      document.body.setAttribute("data-theme", theme);
+      document.body.setAttribute('data-theme', theme);
     }
-    localStorage.setItem("dashboardTheme", theme);
-    document.querySelectorAll('.theme-btn').forEach(btn => {
-      btn.classList.toggle('active', btn.getAttribute('data-theme') === theme);
+    const icon = document.getElementById('currentThemeIcon');
+    if (icon) icon.innerText = THEME_ICONS[idx];
+    localStorage.setItem('dashboardTheme', idx);
+  }
+  const themeBtn = document.getElementById('themeModeToggle');
+  themeIndex = Number(localStorage.getItem('dashboardTheme')) || 0;
+  if (themeIndex >= THEMES.length) themeIndex = 0;
+  applyTheme(themeIndex);
+  if (themeBtn) {
+    themeBtn.addEventListener('click', () => {
+      themeIndex = (themeIndex + 1) % THEMES.length;
+      applyTheme(themeIndex);
     });
   }
-  const savedTheme = localStorage.getItem("dashboardTheme") || "light";
-  setTheme(savedTheme);
-  document.querySelectorAll('.theme-btn').forEach(btn => {
-    btn.addEventListener('click', function() {
-      setTheme(this.getAttribute('data-theme'));
-    });
-  });
 });

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -22,42 +22,29 @@
   <!-- JS: Theme Toggle -->
   <script>
     const THEME_KEY = "themeMode";
-    function setTheme(mode) {
+    const THEMES = ["light", "dark", "funky"];
+    const THEME_ICONS = ["☀️", "🌙", "🎨"];
+    let themeIndex = 0;
+    function applyTheme(idx) {
+      const mode = THEMES[idx];
       document.documentElement.setAttribute("data-theme", mode);
       localStorage.setItem(THEME_KEY, mode);
       document.cookie = THEME_KEY + "=" + mode + ";path=/;max-age=31536000";
-    }
-    function getPersistedTheme() {
-      let mode = localStorage.getItem(THEME_KEY);
-      if (!mode) {
-        const cookie = document.cookie.split('; ').find(r => r.startsWith(THEME_KEY + '='));
-        if (cookie) mode = cookie.split('=')[1];
-      }
-      return mode || "light";
-    }
-    function bindThemeButtons() {
-      const buttons = document.querySelectorAll('.theme-btn[data-theme]');
-      buttons.forEach(btn => {
-        btn.addEventListener('click', e => {
-          const mode = btn.getAttribute('data-theme');
-          setTheme(mode);
-          buttons.forEach(b => b.classList.remove('active'));
-          btn.classList.add('active');
-        });
-      });
+      const icon = document.getElementById("currentThemeIcon");
+      if (icon) icon.innerText = THEME_ICONS[idx];
     }
     document.addEventListener("DOMContentLoaded", () => {
-      const mode = getPersistedTheme();
-      setTheme(mode);
-      const buttons = document.querySelectorAll('.theme-btn[data-theme]');
-      buttons.forEach(btn => {
-        if (btn.getAttribute('data-theme') === mode) {
-          btn.classList.add('active');
-        } else {
-          btn.classList.remove('active');
-        }
-      });
-      bindThemeButtons();
+      const btn = document.getElementById("themeModeToggle");
+      const persisted = localStorage.getItem(THEME_KEY) || "light";
+      themeIndex = THEMES.indexOf(persisted);
+      if (themeIndex === -1) themeIndex = 0;
+      applyTheme(themeIndex);
+      if (btn) {
+        btn.addEventListener("click", () => {
+          themeIndex = (themeIndex + 1) % THEMES.length;
+          applyTheme(themeIndex);
+        });
+      }
     });
   </script>
   <!-- JS: Cyclone Action Toasts -->

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -23,14 +23,12 @@
   </div>
   <div class="title-bar-actions d-flex align-items-center gap-3 ms-auto">
     <div class="config-bar d-flex align-items-center gap-2">
-      <a id="layoutModeToggle" class="btn config-btn" href="#" role="button" title="Switch View Mode">
+      <a id="layoutModeToggle" class="btn config-btn layout-toggle-btn" href="#" role="button" title="Switch View Mode">
         <span id="currentLayoutIcon">🖥️</span>
       </a>
-      <div class="theme-toggle-group" id="themeToggleGroup">
-        <a class="btn config-btn theme-btn" href="#" role="button" data-theme="light" title="Light Theme">☀️</a>
-        <a class="btn config-btn theme-btn" href="#" role="button" data-theme="dark" title="Dark Theme">🌙</a>
-        <a class="btn config-btn theme-btn" href="#" role="button" data-theme="funky" title="Funky Theme">🎨</a>
-      </div>
+      <a id="themeModeToggle" class="btn config-btn theme-btn" href="#" role="button" title="Switch Theme">
+        <span id="currentThemeIcon">☀️</span>
+      </a>
     </div>
     <div class="cyclone-bar d-flex align-items-center gap-2 ms-3">
         <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="sync"   title="Jupiter Sync"><span>🪐</span></a>


### PR DESCRIPTION
## Summary
- revert layout mode buttons back to a single toggle
- toggle theme with a single icon button
- update associated JS and CSS
- adjust dashboard and title bar templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*