### PR TITLE
Add Heat/Hedge report link

### DIFF
--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -7,6 +7,7 @@
     <a class="btn btn-light nav-icon-btn" href="/sonic_labs/hedge_labs" title="Hedge Labs"><span>🧪</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/alert_thresholds" title="Alert Limits"><span>🚨</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/status_page" title="Alert Status"><span>🎛️</span></a>
+    <a class="btn btn-light nav-icon-btn" href="/alerts/alert_matrix" title="Heat/Hedge Report"><span>🔥</span></a>
     <a class="btn btn-light nav-icon-btn" href="/system/xcom_config" title="XCom Config"><span>🔌</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">


### PR DESCRIPTION
## Summary
- add missing Heat/Hedge report icon to title bar navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*