### PR TITLE
Fix app context for background tasks

### DIFF
--- a/cyclone/cyclone_bp.py
+++ b/cyclone/cyclone_bp.py
@@ -10,16 +10,19 @@ cyclone_bp = Blueprint("cyclone", __name__, template_folder=".", url_prefix="/cy
 
 # --- Smart Background Runner ---
 def run_in_background(task_func, name="UnnamedTask"):
+    app = current_app._get_current_object()
+
     def wrapper():
         try:
             log.info(f"🧵 Starting background task: {name}", source="AsyncRunner")
 
-            if inspect.iscoroutinefunction(task_func):
-                asyncio.run(task_func())
-            else:
-                result = task_func()
-                if inspect.iscoroutine(result):
-                    asyncio.run(result)
+            with app.app_context():
+                if inspect.iscoroutinefunction(task_func):
+                    asyncio.run(task_func())
+                else:
+                    result = task_func()
+                    if inspect.iscoroutine(result):
+                        asyncio.run(result)
 
             log.success(f"✅ Completed background task: {name}", source="AsyncRunner")
 


### PR DESCRIPTION
## Summary
- ensure background tasks in Cyclone use Flask application context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*