### PR TITLE
Add parallax effect to dashboard

### DIFF
--- a/static/css/dashboard_parallax.css
+++ b/static/css/dashboard_parallax.css
@@ -1,0 +1,22 @@
+/* Parallax effect for Sonic Dashboard page */
+body.dashboard-parallax {
+  background-image: url('/static/images/cityscape3.jpg');
+  background-attachment: fixed;
+  background-size: cover;
+  background-position: center;
+}
+
+body.dashboard-parallax::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: inherit;
+  background-size: inherit;
+  background-position: inherit;
+  transform: translateZ(-1px) scale(1.5);
+  z-index: -1;
+  pointer-events: none;
+}

--- a/static/js/dashboard_parallax.js
+++ b/static/js/dashboard_parallax.js
@@ -1,0 +1,6 @@
+// Add parallax class to body on dashboard load
+console.log('dashboard_parallax.js loaded');
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.body.classList.add('dashboard-parallax');
+});

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/liquidation_bars.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_middle.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_parallax.css') }}">
 
   <!-- Add any additional CSS files here -->
 {% endblock %}
@@ -112,4 +113,5 @@
   <script src="{{ url_for('static', filename='js/dashboard_bottom.js') }}"></script>
   <script src="{{ url_for('static', filename='js/size_pie.js') }}"></script>
   <script src="{{ url_for('static', filename='js/debug_outlines.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/dashboard_parallax.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated parallax CSS file for the dashboard
- add dashboard parallax JS to toggle effect
- include new assets in the dashboard template

## Testing
- `pytest -q` *(fails: 40 errors during collection)*