### PR TITLE
Fix heat icon link

### DIFF
--- a/static/js/alert_matrix.js
+++ b/static/js/alert_matrix.js
@@ -1,0 +1,2 @@
+// Placeholder script for the alert matrix page
+console.debug('Alert matrix script loaded');

--- a/templates/components/alert_card.html
+++ b/templates/components/alert_card.html
@@ -1,0 +1,17 @@
+<div class="col-md-4 mb-3">
+  <div class="card h-100 alert-card">
+    <div class="card-body p-2">
+      <div class="d-flex align-items-center mb-2">
+        {% set img = alert.asset_image %}
+        <img class="asset-icon me-2" src="{{ url_for('static', filename='images/' + img) }}" alt="{{ alert.asset }}" width="24" height="24">
+        <strong class="me-auto">{{ alert.asset or 'N/A' }}</strong>
+        <span class="badge text-bg-secondary">{{ alert.level }}</span>
+      </div>
+      <div class="small">
+        <div>Type: {{ alert.alert_type }}</div>
+        <div>Value: {{ "{:,.2f}".format(alert.evaluated_value or 0) }}</div>
+        <div>Trigger: {{ "{:,.2f}".format(alert.trigger_value or 0) }}</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/components/hedge_card.html
+++ b/templates/components/hedge_card.html
@@ -1,0 +1,9 @@
+<tr>
+  <td>{{ hedge.id }}</td>
+  <td>{{ "{:,.2f}".format(hedge.total_long_size or 0) }}</td>
+  <td>{{ "{:,.2f}".format(hedge.total_short_size or 0) }}</td>
+  <td>{{ "{:,.2f}".format(hedge.long_heat_index or 0) }}</td>
+  <td>{{ "{:,.2f}".format(hedge.short_heat_index or 0) }}</td>
+  <td>{{ "{:,.2f}".format(hedge.total_heat_index or 0) }}</td>
+  <td>{{ hedge.notes or '' }}</td>
+</tr>


### PR DESCRIPTION
## Summary
- add placeholder script for Alert Matrix page
- add AlertCard and HedgeCard templates so Alert Matrix can render

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*