### PR TITLE
Add hedge report link and page styling

### DIFF
--- a/sonic_app.py
+++ b/sonic_app.py
@@ -101,6 +101,12 @@ def hedge_calculator_redirect():
     """Redirect to the Hedge Calculator page within the system blueprint."""
     return redirect(url_for("system.hedge_calculator_page"))
 
+# --- Hedge Report Redirect ---
+@app.route("/hedge_report")
+def hedge_report_redirect():
+    """Redirect to the Hedge Report page within the system blueprint."""
+    return redirect(url_for("system.hedge_report_page"))
+
 if "dashboard.index" in app.view_functions:
     app.add_url_rule("/dashboard", endpoint="dash", view_func=app.view_functions["dashboard.index"])
 

--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -6,7 +6,7 @@ import json
 from positions.position_sync_service import PositionSyncService  # noqa: F401
 from positions.position_core_service import PositionCoreService  # noqa: F401
 from core.core_imports import retry_on_locked
-from app.system_bp import hedge_calculator_page
+from app.system_bp import hedge_calculator_page, hedge_report_page
 
 sonic_labs_bp = Blueprint("sonic_labs", __name__, template_folder="templates")
 
@@ -15,6 +15,13 @@ sonic_labs_bp = Blueprint("sonic_labs", __name__, template_folder="templates")
 def hedge_calculator():
     """Delegate to the system blueprint implementation."""
     return hedge_calculator_page()
+
+
+@sonic_labs_bp.route("/hedge_report", methods=["GET"])
+@retry_on_locked()
+def hedge_report():
+    """Delegate to the system blueprint implementation for hedge report."""
+    return hedge_report_page()
 
 @sonic_labs_bp.route("/sonic_sauce", methods=["GET"])
 def get_sonic_sauce():

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -1,0 +1,380 @@
+{% extends "base.html" %}
+{% block title %}Hedge Report{% endblock %}
+
+{% block extra_styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+{% endblock %}
+
+{% block content %}
+{% include "title_bar.html" %}
+
+{% set hd = heat_data|default({}) %}
+
+<style>
+/***********************
+Remove gutters so the two cards/tables meet flush in the middle
+***********************/
+.row.g-0 {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+/* Cards: remove default border-radius, stretch to 100% so center edges meet seamlessly */
+.card-no-gap {
+  border-radius: 0 !important;
+  height: 100%;
+}
+
+/* Make icons & text align inline when needed */
+.icon-inline {
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/* Both card headers are centered and dark blue + bold */
+.card-header.text-center h3.card-title {
+  color: #003366;  /* Dark blue */
+  font-weight: bold;
+  margin-bottom: 0;
+}
+
+/* Subtle background colors for each card */
+.card-short {
+  background: #edf4ff;  /* Light bluish for SHORT */
+}
+.card-long {
+  background: #fffaed;  /* Light yellowish for LONG */
+}
+
+/* Force the entire table (header/body/footer) to share the card's background color */
+#short-table thead th,
+#short-table tbody td,
+#short-table tfoot td {
+  background-color: #edf4ff !important;
+}
+#long-table thead th,
+#long-table tbody td,
+#long-table tfoot td {
+  background-color: #fffaed !important;
+}
+
+/* Center the totals row text */
+tfoot tr.text-center > td {
+  text-align: center !important;
+}
+</style>
+
+<!-- Page Title -->
+<h2 class="text-dark mb-4 icon-inline">
+  <span>🦔</span><span>Hedge Report</span>
+</h2>
+
+<div class="container-fluid px-4">
+  <div class="row g-0">
+    <!-- SHORT side -->
+    <div class="col-md-6 pe-0">
+      <div class="card card-no-gap card-short" style="border-right: 1px solid #dee2e6;">
+        <div class="card-header text-center">
+          <h3 class="card-title icon-inline">
+            <span>📉</span><span>SHORT</span>
+          </h3>
+        </div>
+        <div class="card-body p-0">
+          <!-- Give the table an ID so we can style it (#short-table) -->
+          <table id="short-table" class="table table-sm table-bordered mb-0">
+            <thead>
+              <tr class="fw-bold">
+                <th style="width: 110px;">
+                  <span class="icon-inline">📊 Asset</span>
+                </th>
+                <th style="width: 110px;">
+                  <span class="icon-inline">💰 Collateral</span>
+                </th>
+                <th style="width: 110px;">
+                  <span class="icon-inline">📈 Value</span>
+                </th>
+                <th style="width: 90px;">
+                  <span class="icon-inline">⚙️ Leverage</span>
+                </th>
+                <th style="width: 90px;">
+                  <span class="icon-inline">📉 Travel %</span>
+                </th>
+                <th style="width: 110px;">
+                  <span class="icon-inline">📏 Size</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for asset in ["BTC", "ETH", "SOL"] %}
+                {% set asset_data = hd.get(asset, {}) %}
+                {% set pos = asset_data.get('short') %}
+                {% if not pos %}
+                  <tr>
+                    <td colspan="6" class="text-center text-muted">No data</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td>
+                      <span class="icon-inline">
+                        {% if pos.asset == "BTC" %}
+                          <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
+                        {% elif pos.asset == "ETH" %}
+                          <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
+                        {% elif pos.asset == "SOL" %}
+                          <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
+                        {% endif %}
+                        {{ pos.asset }}
+                      </span>
+                    </td>
+                    <td>{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
+                    <td>{{ "{:,}".format(pos.value|float|round(2)) }}</td>
+                    <td>{{ pos.leverage|float|round(2) }}</td>
+                    <td>{{ pos.travel_percent|float|round(2) }}%</td>
+                    <td>{{ "{:,}".format(pos.size|float|round(2)) }}</td>
+                  </tr>
+                {% endif %}
+              {% endfor %}
+            </tbody>
+            <tfoot>
+              <tr class="fw-bold text-center">
+                {% set short_totals = hd.get('totals', {}).get('short', {}) %}
+                <td>
+                  <span class="icon-inline">
+                    {% if short_totals.get('asset') %}
+                      {% if short_totals.asset == "BTC" %}
+                        <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
+                      {% elif short_totals.asset == "ETH" %}
+                        <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
+                      {% elif short_totals.asset == "SOL" %}
+                        <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
+                      {% endif %}
+                      {{ short_totals.asset }}
+                    {% else %}
+                      Short
+                    {% endif %}
+                  </span>
+                </td>
+                <td>{{ "{:,}".format(short_totals.get('collateral',0)|float|round(2)) }}</td>
+                <td>{{ "{:,}".format(short_totals.get('value',0)|float|round(2)) }}</td>
+                <td>{{ short_totals.get('leverage',0)|float|round(2) }}</td>
+                <td>{{ short_totals.get('travel_percent',0)|float|round(2) }}%</td>
+                <td>{{ "{:,}".format(short_totals.get('size',0)|float|round(2)) }}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- LONG side -->
+    <div class="col-md-6 ps-0">
+      <div class="card card-no-gap card-long" style="border-left: 1px solid #dee2e6;">
+        <div class="card-header text-center">
+          <h3 class="card-title icon-inline">
+            <span>📈</span><span>LONG</span>
+          </h3>
+        </div>
+        <div class="card-body p-0">
+          <!-- Give the table an ID so we can style it (#long-table) -->
+          <table id="long-table" class="table table-sm table-bordered mb-0">
+            <thead>
+              <tr class="fw-bold">
+                <th style="width: 110px;">
+                  <span class="icon-inline">📏 Size</span>
+                </th>
+                <th style="width: 90px;">
+                  <span class="icon-inline">📉 Travel %</span>
+                </th>
+                <th style="width: 90px;">
+                  <span class="icon-inline">⚙️ Leverage</span>
+                </th>
+                <th style="width: 110px;">
+                  <span class="icon-inline">📈 Value</span>
+                </th>
+                <th style="width: 110px;">
+                  <span class="icon-inline">💰 Collateral</span>
+                </th>
+                <th style="width: 110px;">
+                  <span class="icon-inline">📊 Asset</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for asset in ["BTC", "ETH", "SOL"] %}
+                {% set asset_data = hd.get(asset, {}) %}
+                {% set pos = asset_data.get('long') %}
+                {% if not pos %}
+                  <tr>
+                    <td colspan="6" class="text-center text-muted">No data</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td>{{ "{:,}".format(pos.size|float|round(2)) }}</td>
+                    <td>{{ pos.travel_percent|float|round(2) }}%</td>
+                    <td>{{ pos.leverage|float|round(2) }}</td>
+                    <td>{{ "{:,}".format(pos.value|float|round(2)) }}</td>
+                    <td>{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
+                    <td>
+                      <span class="icon-inline">
+                        {% if pos.asset == "BTC" %}
+                          <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
+                        {% elif pos.asset == "ETH" %}
+                          <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
+                        {% elif pos.asset == "SOL" %}
+                          <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
+                        {% endif %}
+                        {{ pos.asset }}
+                      </span>
+                    </td>
+                  </tr>
+                {% endif %}
+              {% endfor %}
+            </tbody>
+            <tfoot>
+              <tr class="fw-bold text-center">
+                {% set long_totals = hd.get('totals', {}).get('long', {}) %}
+                <td>{{ "{:,}".format(long_totals.get('size',0)|float|round(2)) }}</td>
+                <td>{{ long_totals.get('travel_percent',0)|float|round(2) }}%</td>
+                <td>{{ long_totals.get('leverage',0)|float|round(2) }}</td>
+                <td>{{ "{:,}".format(long_totals.get('value',0)|float|round(2)) }}</td>
+                <td>{{ "{:,}".format(long_totals.get('collateral',0)|float|round(2)) }}</td>
+                <td>
+                  {% if long_totals.get('asset') %}
+                    <span class="icon-inline">
+                      {% if long_totals.asset == "BTC" %}
+                        <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
+                      {% elif long_totals.asset == "ETH" %}
+                        <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
+                      {% elif long_totals.asset == "SOL" %}
+                        <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
+                      {% endif %}
+                      {{ long_totals.asset }}
+                    </span>
+                  {% else %}
+                    Long
+                  {% endif %}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Charts Section -->
+{% set shortTotals = hd.get('totals', {}).get('short', {}) %}
+{% set longTotals  = hd.get('totals', {}).get('long',  {}) %}
+{% set shortSize   = shortTotals.get('size', 0)|float|round(2) %}
+{% set longSize    = longTotals.get('size', 0)|float|round(2) %}
+
+{% set btcShort = hd.get("BTC", {}).get("short", {}).get("size", 0)|float|round(2) %}
+{% set btcLong  = hd.get("BTC", {}).get("long",  {}).get("size", 0)|float|round(2) %}
+{% set ethShort = hd.get("ETH", {}).get("short", {}).get("size", 0)|float|round(2) %}
+{% set ethLong  = hd.get("ETH", {}).get("long",  {}).get("size", 0)|float|round(2) %}
+{% set solShort = hd.get("SOL", {}).get("short", {}).get("size", 0)|float|round(2) %}
+{% set solLong  = hd.get("SOL", {}).get("long",  {}).get("size", 0)|float|round(2) %}
+
+{% set btcTotal = btcShort + btcLong %}
+{% set ethTotal = ethShort + ethLong %}
+{% set solTotal = solShort + solLong %}
+
+<div class="d-flex flex-wrap justify-content-around mt-5">
+  <div style="width: 400px;">
+    <canvas id="sizeDist"></canvas>
+  </div>
+  <div style="width: 400px;">
+    <canvas id="assetDist"></canvas>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels"></script>
+<script>
+(function() {
+  // Size Distribution chart
+  const shortSize = {{ shortSize }};
+  const longSize  = {{ longSize }};
+  const sizeCtx   = document.getElementById('sizeDist').getContext('2d');
+  new Chart(sizeCtx, {
+    type: 'pie',
+    data: {
+      labels: ['Short', 'Long'],
+      datasets: [{
+        data: [shortSize, longSize],
+        backgroundColor: ['#f39c12','rgb(52,152,219)']
+      }]
+    },
+    plugins: [ChartDataLabels],
+    options: {
+      plugins: {
+        title: {
+          display: true,
+          text: 'Size Distribution',
+          font: { size:16, weight:'bold' },
+          color: '#000'
+        },
+        legend: { position: 'bottom' },
+        datalabels: {
+          color: '#fff',
+          font: { size:14, weight:'bold' },
+          formatter: (value, ctx) => {
+            const sum = ctx.dataset.data.reduce((a,b)=>a+b,0);
+            return sum>0 ? (value/sum*100).toFixed(1)+'%' : '0%';
+          }
+        }
+      }
+    }
+  });
+
+  // Asset Distribution chart
+  const btcTotal = {{ btcTotal }};
+  const ethTotal = {{ ethTotal }};
+  const solTotal = {{ solTotal }};
+  const assetCtx = document.getElementById('assetDist').getContext('2d');
+  new Chart(assetCtx, {
+    type: 'pie',
+    data: {
+      labels: ['BTC', 'ETH', 'SOL'],
+      datasets: [{
+        data: [btcTotal, ethTotal, solTotal],
+        backgroundColor: ['#F7931A', '#3498db', '#8e44ad']
+      }]
+    },
+    plugins: [ChartDataLabels],
+    options: {
+      plugins: {
+        title: {
+          display: true,
+          text: 'Asset Distribution',
+          font: { size:16, weight:'bold' },
+          color: '#000'
+        },
+        legend: { position: 'bottom' },
+        datalabels: {
+          color:'#fff',
+          font:{ size:14, weight:'bold' },
+          formatter: (value, ctx) => {
+            const sum = ctx.dataset.data.reduce((a,b)=>a+b,0);
+            return sum>0 ? (value/sum*100).toFixed(1)+'%' : '0%';
+          }
+        }
+      }
+    }
+  });
+})();
+</script>
+
+{% endblock content %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+{% endblock %}

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -7,7 +7,7 @@
     <a class="btn btn-light nav-icon-btn" href="/sonic_labs/hedge_labs" title="Hedge Labs"><span>🧪</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/alert_thresholds" title="Alert Limits"><span>🚨</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/status_page" title="Alert Status"><span>🎛️</span></a>
-    <a class="btn btn-light nav-icon-btn" href="/alerts/alert_matrix" title="Heat/Hedge Report"><span>🔥</span></a>
+    <a class="btn btn-light nav-icon-btn" href="/hedge_report" title="Hedge Report"><span>🦔</span></a>
     <a class="btn btn-light nav-icon-btn" href="/system/xcom_config" title="XCom Config"><span>🔌</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">


### PR DESCRIPTION
## Summary
- add Hedge Report to navigation bar with hedgehog icon
- create redirect route `/hedge_report` pointing to system blueprint
- style hedge_report template with title bar and theme/layout toggles

## Testing
- `pytest -q` *(fails: 40 errors during collection)*