### PR TITLE
Add zoom-out parallax animation

### DIFF
--- a/static/css/dashboard_parallax.css
+++ b/static/css/dashboard_parallax.css
@@ -20,3 +20,17 @@ body.dashboard-parallax::before {
   z-index: -1;
   pointer-events: none;
 }
+
+/* Start zoomed in and animate to normal scale */
+body.dashboard-parallax.zoom-out::before {
+  animation: zoomOutParallax 1s ease-out forwards;
+}
+
+@keyframes zoomOutParallax {
+  from {
+    transform: translateZ(-1px) scale(1.5);
+  }
+  to {
+    transform: translateZ(-1px) scale(1);
+  }
+}

--- a/static/js/dashboard_parallax.js
+++ b/static/js/dashboard_parallax.js
@@ -2,5 +2,5 @@
 console.log('dashboard_parallax.js loaded');
 
 window.addEventListener('DOMContentLoaded', () => {
-  document.body.classList.add('dashboard-parallax');
+  document.body.classList.add('dashboard-parallax', 'zoom-out');
 });


### PR DESCRIPTION
## Summary
- add a new CSS animation to start zoomed in and settle at normal scale
- update parallax script to enable the animation on load

## Testing
- `pytest -q` *(fails: 40 errors during collection)*