### PR TITLE
Change parallax background to wally.jg

### DIFF
--- a/static/css/dashboard_parallax.css
+++ b/static/css/dashboard_parallax.css
@@ -1,6 +1,6 @@
 /* Parallax effect for Sonic Dashboard page */
 body.dashboard-parallax {
-  background-image: url('/static/images/cityscape3.jpg');
+  background-image: url('/static/images/wally.jg');
   background-attachment: fixed;
   background-size: cover;
   background-position: center;


### PR DESCRIPTION
## Summary
- set dashboard parallax background to `wally.jg`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*