### PR TITLE
Refactor hedge report styles

### DIFF
--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -1,0 +1,53 @@
+/***********************
+Remove gutters so the two cards/tables meet flush in the middle
+***********************/
+.row.g-0 {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+/* Cards: remove default border-radius, stretch to 100% so center edges meet seamlessly */
+.card-no-gap {
+  border-radius: 0 !important;
+  height: 100%;
+}
+
+/* Make icons & text align inline when needed */
+.icon-inline {
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/* Both card headers are centered and dark blue + bold */
+.card-header.text-center h3.card-title {
+  color: #003366;  /* Dark blue */
+  font-weight: bold;
+  margin-bottom: 0;
+}
+
+/* Subtle background colors for each card */
+.card-short {
+  background: #edf4ff;  /* Light bluish for SHORT */
+}
+.card-long {
+  background: #fffaed;  /* Light yellowish for LONG */
+}
+
+/* Force the entire table (header/body/footer) to share the card's background color */
+#short-table thead th,
+#short-table tbody td,
+#short-table tfoot td {
+  background-color: #edf4ff !important;
+}
+#long-table thead th,
+#long-table tbody td,
+#long-table tfoot td {
+  background-color: #fffaed !important;
+}
+
+/* Center the totals row text */
+tfoot tr.text-center > td {
+  text-align: center !important;
+}

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_report.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -15,62 +16,6 @@
 
 
 {% set hd = heat_data|default({}) %}
-
-<style>
-/***********************
-Remove gutters so the two cards/tables meet flush in the middle
-***********************/
-.row.g-0 {
-  margin-right: 0;
-  margin-left: 0;
-}
-
-/* Cards: remove default border-radius, stretch to 100% so center edges meet seamlessly */
-.card-no-gap {
-  border-radius: 0 !important;
-  height: 100%;
-}
-
-/* Make icons & text align inline when needed */
-.icon-inline {
-  white-space: nowrap;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-/* Both card headers are centered and dark blue + bold */
-.card-header.text-center h3.card-title {
-  color: #003366;  /* Dark blue */
-  font-weight: bold;
-  margin-bottom: 0;
-}
-
-/* Subtle background colors for each card */
-.card-short {
-  background: #edf4ff;  /* Light bluish for SHORT */
-}
-.card-long {
-  background: #fffaed;  /* Light yellowish for LONG */
-}
-
-/* Force the entire table (header/body/footer) to share the card's background color */
-#short-table thead th,
-#short-table tbody td,
-#short-table tfoot td {
-  background-color: #edf4ff !important;
-}
-#long-table thead th,
-#long-table tbody td,
-#long-table tfoot td {
-  background-color: #fffaed !important;
-}
-
-/* Center the totals row text */
-tfoot tr.text-center > td {
-  text-align: center !important;
-}
-</style>
 
 <!-- Page Title -->
 <h2 class="text-dark mb-4 icon-inline">


### PR DESCRIPTION
## Summary
- move Hedge Report custom styles to `static/css/hedge_report.css`
- link to the new stylesheet from the report template
- remove inline `<style>` block from Hedge Report

## Testing
- `pytest -q` *(fails: 40 errors during collection)*