### PR TITLE
Fix CSS background image path

### DIFF
--- a/static/css/dashboard_parallax.css
+++ b/static/css/dashboard_parallax.css
@@ -1,6 +1,6 @@
 /* Parallax effect for Sonic Dashboard page */
 body.dashboard-parallax {
-  background-image: url('/static/images/wally.jg');
+  background-image: url('/static/images/Wally.png');
   background-attachment: fixed;
   background-size: cover;
   background-position: center;

--- a/static/css/sonic_themes.css
+++ b/static/css/sonic_themes.css
@@ -72,7 +72,7 @@
   --primary-hover: #4e87f0;
   --accent: #f4eef4;
   --container-bg: #ffffff;
-  --body-bg-image: url('/static/images/wally.png');
+  --body-bg-image: url('/static/images/Wally.png');
   --section-bg-image: url('/static/images/wally2.png');
 }
 
@@ -165,7 +165,7 @@ body {
   --primary-hover: #4e87f0;
   --accent: #f4eef4;
   --container-bg: #ffffff;
-  --body-bg-image: url('/static/images/wally.png');
+  --body-bg-image: url('/static/images/Wally.png');
   --section-bg-image: url('/static/images/wally2.png');
 }
 


### PR DESCRIPTION
## Summary
- point CSS to correct Wally image

## Testing
- `pytest -q` *(fails: 40 errors during collection)*