### PR TITLE
Redesign hedge report with sortable tables

### DIFF
--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -1,53 +1,64 @@
-/***********************
-Remove gutters so the two cards/tables meet flush in the middle
-***********************/
-.row.g-0 {
-  margin-right: 0;
-  margin-left: 0;
+.positions-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  min-height: 200px;
 }
 
-/* Cards: remove default border-radius, stretch to 100% so center edges meet seamlessly */
-.card-no-gap {
-  border-radius: 0 !important;
-  height: 100%;
+.positions-table {
+  background: var(--container-bg);
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 1rem;
 }
 
-/* Make icons & text align inline when needed */
-.icon-inline {
-  white-space: nowrap;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
+.positions-table thead th {
+  background: var(--title-bar-bg);
+  color: var(--panel-title);
+  font-weight: 700;
+  padding: 0.7em 0.6em;
+  border-bottom: 2px solid var(--panel-border);
+  user-select: none;
+  cursor: pointer;
+  vertical-align: middle;
 }
 
-/* Both card headers are centered and dark blue + bold */
-.card-header.text-center h3.card-title {
-  color: #003366;  /* Dark blue */
+.positions-table th.left,
+.positions-table td.left { text-align: left; }
+.positions-table th.right,
+.positions-table td.right { text-align: right; }
+
+.positions-table tbody td {
+  background: var(--container-bg);
+  color: var(--text);
+  padding: 0.7em 0.6em;
+  border-bottom: 1px solid var(--panel-border);
+  vertical-align: middle;
+}
+
+.positions-table tfoot td {
+  background: var(--accent);
+  color: var(--text);
   font-weight: bold;
-  margin-bottom: 0;
+  border-top: 2px solid var(--panel-border);
+  text-align: right;
 }
+.positions-table tfoot td.left { text-align: left; }
 
-/* Subtle background colors for each card */
-.card-short {
-  background: #edf4ff;  /* Light bluish for SHORT */
+.sort-indicator {
+  font-size: 1em;
+  margin-left: 4px;
+  color: var(--panel-title);
+  opacity: 0.8;
 }
-.card-long {
-  background: #fffaed;  /* Light yellowish for LONG */
-}
+th.sorted-asc .sort-indicator,
+th.sorted-desc .sort-indicator { color: var(--primary); }
 
-/* Force the entire table (header/body/footer) to share the card's background color */
-#short-table thead th,
-#short-table tbody td,
-#short-table tfoot td {
-  background-color: #edf4ff !important;
-}
-#long-table thead th,
-#long-table tbody td,
-#long-table tfoot td {
-  background-color: #fffaed !important;
-}
-
-/* Center the totals row text */
-tfoot tr.text-center > td {
-  text-align: center !important;
+.no-data {
+  text-align: center;
+  color: var(--text);
+  padding: 1.2rem;
+  font-style: italic;
 }

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -23,194 +23,150 @@
 </h2>
 
 <div class="container-fluid px-4">
-  <div class="row g-0">
-    <!-- SHORT side -->
-    <div class="col-md-6 pe-0">
-      <div class="card card-no-gap card-short" style="border-right: 1px solid #dee2e6;">
-        <div class="card-header text-center">
-          <h3 class="card-title icon-inline">
-            <span>📉</span><span>SHORT</span>
-          </h3>
-        </div>
-        <div class="card-body p-0">
-          <!-- Give the table an ID so we can style it (#short-table) -->
-          <table id="short-table" class="table table-sm table-bordered mb-0">
-            <thead>
-              <tr class="fw-bold">
-                <th style="width: 110px;">
-                  <span class="icon-inline">📊 Asset</span>
-                </th>
-                <th style="width: 110px;">
-                  <span class="icon-inline">💰 Collateral</span>
-                </th>
-                <th style="width: 110px;">
-                  <span class="icon-inline">📈 Value</span>
-                </th>
-                <th style="width: 90px;">
-                  <span class="icon-inline">⚙️ Leverage</span>
-                </th>
-                <th style="width: 90px;">
-                  <span class="icon-inline">📉 Travel %</span>
-                </th>
-                <th style="width: 110px;">
-                  <span class="icon-inline">📏 Size</span>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for asset in ["BTC", "ETH", "SOL"] %}
-                {% set asset_data = hd.get(asset, {}) %}
-                {% set pos = asset_data.get('short') %}
-                {% if not pos %}
-                  <tr>
-                    <td colspan="6" class="text-center text-muted">No data</td>
-                  </tr>
-                {% else %}
-                  <tr>
-                    <td>
-                      <span class="icon-inline">
-                        {% if pos.asset == "BTC" %}
-                          <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
-                        {% elif pos.asset == "ETH" %}
-                          <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
-                        {% elif pos.asset == "SOL" %}
-                          <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
-                        {% endif %}
-                        {{ pos.asset }}
-                      </span>
-                    </td>
-                    <td>{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
-                    <td>{{ "{:,}".format(pos.value|float|round(2)) }}</td>
-                    <td>{{ pos.leverage|float|round(2) }}</td>
-                    <td>{{ pos.travel_percent|float|round(2) }}%</td>
-                    <td>{{ "{:,}".format(pos.size|float|round(2)) }}</td>
-                  </tr>
-                {% endif %}
-              {% endfor %}
-            </tbody>
-            <tfoot>
-              <tr class="fw-bold text-center">
-                {% set short_totals = hd.get('totals', {}).get('short', {}) %}
-                <td>
-                  <span class="icon-inline">
-                    {% if short_totals.get('asset') %}
-                      {% if short_totals.asset == "BTC" %}
+  <div class="row">
+    <div class="col-md-6">
+      <div class="positions-table-wrapper">
+        <h3 class="section-title icon-inline text-center mb-2"><span>📉</span><span>SHORT</span></h3>
+        <table id="short-table" class="positions-table">
+          <thead>
+            <tr>
+              <th class="sortable left" data-col-index="0">Asset <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="1">Collateral <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="2">Value <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="3">Leverage <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="4">Travel % <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="5">Size <span class="sort-indicator"></span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for asset in ["BTC", "ETH", "SOL"] %}
+              {% set asset_data = hd.get(asset, {}) %}
+              {% set pos = asset_data.get('short') %}
+              {% if not pos %}
+                <tr class="no-data-row"><td colspan="6" class="no-data">No data</td></tr>
+              {% else %}
+                <tr>
+                  <td class="left">
+                    <span class="icon-inline">
+                      {% if pos.asset == "BTC" %}
                         <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
-                      {% elif short_totals.asset == "ETH" %}
+                      {% elif pos.asset == "ETH" %}
                         <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
-                      {% elif short_totals.asset == "SOL" %}
+                      {% elif pos.asset == "SOL" %}
                         <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
                       {% endif %}
-                      {{ short_totals.asset }}
-                    {% else %}
-                      Short
+                      {{ pos.asset }}
+                    </span>
+                  </td>
+                  <td class="right">{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
+                  <td class="right">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
+                  <td class="right">{{ pos.leverage|float|round(2) }}</td>
+                  <td class="right">{{ pos.travel_percent|float|round(2) }}%</td>
+                  <td class="right">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
+                </tr>
+              {% endif %}
+            {% endfor %}
+          </tbody>
+          <tfoot>
+            <tr class="fw-bold">
+              {% set short_totals = hd.get('totals', {}).get('short', {}) %}
+              <td class="left">
+                <span class="icon-inline">
+                  {% if short_totals.get('asset') %}
+                    {% if short_totals.asset == "BTC" %}
+                      <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
+                    {% elif short_totals.asset == "ETH" %}
+                      <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
+                    {% elif short_totals.asset == "SOL" %}
+                      <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
                     {% endif %}
-                  </span>
-                </td>
-                <td>{{ "{:,}".format(short_totals.get('collateral',0)|float|round(2)) }}</td>
-                <td>{{ "{:,}".format(short_totals.get('value',0)|float|round(2)) }}</td>
-                <td>{{ short_totals.get('leverage',0)|float|round(2) }}</td>
-                <td>{{ short_totals.get('travel_percent',0)|float|round(2) }}%</td>
-                <td>{{ "{:,}".format(short_totals.get('size',0)|float|round(2)) }}</td>
-              </tr>
-            </tfoot>
-          </table>
-        </div>
+                    {{ short_totals.asset }}
+                  {% else %}
+                    Short
+                  {% endif %}
+                </span>
+              </td>
+              <td class="right">{{ "{:,}".format(short_totals.get('collateral',0)|float|round(2)) }}</td>
+              <td class="right">{{ "{:,}".format(short_totals.get('value',0)|float|round(2)) }}</td>
+              <td class="right">{{ short_totals.get('leverage',0)|float|round(2) }}</td>
+              <td class="right">{{ short_totals.get('travel_percent',0)|float|round(2) }}%</td>
+              <td class="right">{{ "{:,}".format(short_totals.get('size',0)|float|round(2)) }}</td>
+            </tr>
+          </tfoot>
+        </table>
       </div>
     </div>
 
-    <!-- LONG side -->
-    <div class="col-md-6 ps-0">
-      <div class="card card-no-gap card-long" style="border-left: 1px solid #dee2e6;">
-        <div class="card-header text-center">
-          <h3 class="card-title icon-inline">
-            <span>📈</span><span>LONG</span>
-          </h3>
-        </div>
-        <div class="card-body p-0">
-          <!-- Give the table an ID so we can style it (#long-table) -->
-          <table id="long-table" class="table table-sm table-bordered mb-0">
-            <thead>
-              <tr class="fw-bold">
-                <th style="width: 110px;">
-                  <span class="icon-inline">📏 Size</span>
-                </th>
-                <th style="width: 90px;">
-                  <span class="icon-inline">📉 Travel %</span>
-                </th>
-                <th style="width: 90px;">
-                  <span class="icon-inline">⚙️ Leverage</span>
-                </th>
-                <th style="width: 110px;">
-                  <span class="icon-inline">📈 Value</span>
-                </th>
-                <th style="width: 110px;">
-                  <span class="icon-inline">💰 Collateral</span>
-                </th>
-                <th style="width: 110px;">
-                  <span class="icon-inline">📊 Asset</span>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for asset in ["BTC", "ETH", "SOL"] %}
-                {% set asset_data = hd.get(asset, {}) %}
-                {% set pos = asset_data.get('long') %}
-                {% if not pos %}
-                  <tr>
-                    <td colspan="6" class="text-center text-muted">No data</td>
-                  </tr>
-                {% else %}
-                  <tr>
-                    <td>{{ "{:,}".format(pos.size|float|round(2)) }}</td>
-                    <td>{{ pos.travel_percent|float|round(2) }}%</td>
-                    <td>{{ pos.leverage|float|round(2) }}</td>
-                    <td>{{ "{:,}".format(pos.value|float|round(2)) }}</td>
-                    <td>{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
-                    <td>
-                      <span class="icon-inline">
-                        {% if pos.asset == "BTC" %}
-                          <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
-                        {% elif pos.asset == "ETH" %}
-                          <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
-                        {% elif pos.asset == "SOL" %}
-                          <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
-                        {% endif %}
-                        {{ pos.asset }}
-                      </span>
-                    </td>
-                  </tr>
-                {% endif %}
-              {% endfor %}
-            </tbody>
-            <tfoot>
-              <tr class="fw-bold text-center">
-                {% set long_totals = hd.get('totals', {}).get('long', {}) %}
-                <td>{{ "{:,}".format(long_totals.get('size',0)|float|round(2)) }}</td>
-                <td>{{ long_totals.get('travel_percent',0)|float|round(2) }}%</td>
-                <td>{{ long_totals.get('leverage',0)|float|round(2) }}</td>
-                <td>{{ "{:,}".format(long_totals.get('value',0)|float|round(2)) }}</td>
-                <td>{{ "{:,}".format(long_totals.get('collateral',0)|float|round(2)) }}</td>
-                <td>
-                  {% if long_totals.get('asset') %}
+    <div class="col-md-6 mt-4 mt-md-0">
+      <div class="positions-table-wrapper">
+        <h3 class="section-title icon-inline text-center mb-2"><span>📈</span><span>LONG</span></h3>
+        <table id="long-table" class="positions-table">
+          <thead>
+            <tr>
+              <th class="sortable left" data-col-index="0">Asset <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="1">Collateral <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="2">Value <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="3">Leverage <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="4">Travel % <span class="sort-indicator"></span></th>
+              <th class="sortable right" data-col-index="5">Size <span class="sort-indicator"></span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for asset in ["BTC", "ETH", "SOL"] %}
+              {% set asset_data = hd.get(asset, {}) %}
+              {% set pos = asset_data.get('long') %}
+              {% if not pos %}
+                <tr class="no-data-row"><td colspan="6" class="no-data">No data</td></tr>
+              {% else %}
+                <tr>
+                  <td class="left">
                     <span class="icon-inline">
-                      {% if long_totals.asset == "BTC" %}
+                      {% if pos.asset == "BTC" %}
                         <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
-                      {% elif long_totals.asset == "ETH" %}
+                      {% elif pos.asset == "ETH" %}
                         <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
-                      {% elif long_totals.asset == "SOL" %}
+                      {% elif pos.asset == "SOL" %}
                         <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
                       {% endif %}
-                      {{ long_totals.asset }}
+                      {{ pos.asset }}
                     </span>
-                  {% else %}
-                    Long
-                  {% endif %}
-                </td>
-              </tr>
-            </tfoot>
-          </table>
-        </div>
+                  </td>
+                  <td class="right">{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
+                  <td class="right">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
+                  <td class="right">{{ pos.leverage|float|round(2) }}</td>
+                  <td class="right">{{ pos.travel_percent|float|round(2) }}%</td>
+                  <td class="right">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
+                </tr>
+              {% endif %}
+            {% endfor %}
+          </tbody>
+          <tfoot>
+            <tr class="fw-bold">
+              {% set long_totals = hd.get('totals', {}).get('long', {}) %}
+              <td class="left">
+                {% if long_totals.get('asset') %}
+                  <span class="icon-inline">
+                    {% if long_totals.asset == "BTC" %}
+                      <img src="/static/images/btc_logo.png" alt="BTC" style="width:20px;">
+                    {% elif long_totals.asset == "ETH" %}
+                      <img src="/static/images/eth_logo.png" alt="ETH" style="width:20px;">
+                    {% elif long_totals.asset == "SOL" %}
+                      <img src="/static/images/sol_logo.png" alt="SOL" style="width:20px;">
+                    {% endif %}
+                    {{ long_totals.asset }}
+                  </span>
+                {% else %}
+                  Long
+                {% endif %}
+              </td>
+              <td class="right">{{ "{:,}".format(long_totals.get('collateral',0)|float|round(2)) }}</td>
+              <td class="right">{{ "{:,}".format(long_totals.get('value',0)|float|round(2)) }}</td>
+              <td class="right">{{ long_totals.get('leverage',0)|float|round(2) }}</td>
+              <td class="right">{{ long_totals.get('travel_percent',0)|float|round(2) }}%</td>
+              <td class="right">{{ "{:,}".format(long_totals.get('size',0)|float|round(2)) }}</td>
+            </tr>
+          </tfoot>
+        </table>
       </div>
     </div>
   </div>
@@ -317,6 +273,59 @@
     }
   });
 })();
+</script>
+
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+  function initSortableTable(selector) {
+    const table = document.querySelector(selector);
+    if (!table) return;
+    const headers = table.querySelectorAll("thead th.sortable");
+    const tbody = table.querySelector("tbody");
+    let currentSort = { col: 0, dir: "asc" };
+
+    function sortTable(colIndex, dir) {
+      const rows = Array.from(tbody.querySelectorAll("tr")).filter(r => !r.classList.contains("no-data-row"));
+      if (rows.length === 0) return;
+      rows.sort((a,b) => {
+        const getVal = row => {
+          const cell = row.children[colIndex];
+          const text = cell.textContent.replace(/[,%]/g, "").trim();
+          const num = parseFloat(text.replace(/[^0-9.-]/g, ""));
+          return isNaN(num) ? text : num;
+        };
+        const aVal = getVal(a);
+        const bVal = getVal(b);
+        if (typeof aVal === "number" && typeof bVal === "number") {
+          return dir === "asc" ? aVal - bVal : bVal - aVal;
+        }
+        return dir === "asc" ? aVal.toString().localeCompare(bVal) : bVal.toString().localeCompare(aVal);
+      });
+      rows.forEach(r => tbody.appendChild(r));
+      headers.forEach((th,i) => {
+        th.classList.remove("sorted-asc","sorted-desc");
+        th.querySelector(".sort-indicator").textContent = "";
+        if (i === colIndex) {
+          th.classList.add(dir === "asc" ? "sorted-asc" : "sorted-desc");
+          th.querySelector(".sort-indicator").textContent = dir === "asc" ? "▲" : "▼";
+        }
+      });
+    }
+
+    headers.forEach((th,i) => {
+      th.addEventListener("click", function() {
+        let dir = "desc";
+        if (currentSort.col === i && currentSort.dir === "desc") dir = "asc";
+        currentSort = { col: i, dir };
+        sortTable(i, dir);
+      });
+    });
+    sortTable(currentSort.col, currentSort.dir);
+  }
+
+  initSortableTable("#short-table");
+  initSortableTable("#long-table");
+});
 </script>
 
 {% endblock content %}


### PR DESCRIPTION
## Summary
- convert the hedge report to use two simple positions tables
- add client-side sorting for each table
- simplify styling for the hedge report tables

## Testing
- `pytest tests/test_hedge_calc_services.py tests/test_hedge_calculator_page.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*