### PR TITLE
Update alert status colors and wallet images

### DIFF
--- a/static/css/alert_status.css
+++ b/static/css/alert_status.css
@@ -85,3 +85,25 @@ th.sorted-desc .sort-indicator { color: var(--primary); }
   background: var(--container-bg);
   box-sizing: border-box;
 }
+
+/* Color coding for alert levels */
+.alert-bars .level-normal .liq-bar-fill,
+.alert-bars .level-normal .liq-flame-container {
+  background: #007bff;
+}
+
+.alert-bars .level-low .liq-bar-fill,
+.alert-bars .level-low .liq-flame-container {
+  background: #28a745;
+}
+
+.alert-bars .level-medium .liq-bar-fill,
+.alert-bars .level-medium .liq-flame-container {
+  background: #ffc107;
+  color: #000;
+}
+
+.alert-bars .level-high .liq-bar-fill,
+.alert-bars .level-high .liq-flame-container {
+  background: #dc3545;
+}

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -58,7 +58,7 @@
               <td class="left">{{ alert.level }}</td>
               <td class="left">{{ alert.status }}</td>
               {% set wallet_img = alert.wallet_image %}
-              {% if wallet_img and (wallet_img.startswith('http://') or wallet_img.startswith('https://')) %}
+              {% if wallet_img and (wallet_img.startswith('http://') or wallet_img.startswith('https://') or wallet_img.startswith('/static/')) %}
                 <td class="left"><img class="wallet-icon" src="{{ wallet_img }}" alt="{{ alert.wallet_name or alert.asset }}"><span style="display:none">{{ alert.wallet_name or 'N/A' }}</span></td>
               {% else %}
                 <td class="left"><img class="wallet-icon" src="{{ url_for('static', filename=wallet_img if wallet_img else 'images/' + alert.asset_image) }}" alt="{{ alert.wallet_name or alert.asset }}"><span style="display:none">{{ alert.wallet_name or 'N/A' }}</span></td>
@@ -80,9 +80,9 @@
       {% if alerts %}
         {% for alert in alerts %}
           {% if alert.travel_percent is defined and alert.travel_percent is not none %}
-            <div class="liq-row" data-alert-id="{{ alert.id }}">
+            <div class="liq-row level-{{ alert.level|lower }}" data-alert-id="{{ alert.id }}">
               {% set wallet_img = alert.wallet_image %}
-              {% if wallet_img and (wallet_img.startswith('http://') or wallet_img.startswith('https://')) %}
+              {% if wallet_img and (wallet_img.startswith('http://') or wallet_img.startswith('https://') or wallet_img.startswith('/static/')) %}
               <img class="wallet-icon" src="{{ wallet_img }}" alt="{{ alert.wallet_name or alert.asset }}" />
               {% else %}
               <img class="wallet-icon" src="{{ url_for('static', filename=wallet_img if wallet_img else 'images/' + alert.asset_image) }}" alt="{{ alert.wallet_name or alert.asset }}" />


### PR DESCRIPTION
## Summary
- color code proximity bars based on alert level
- handle wallet image paths that start with `/static/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*