### PR TITLE
Add test route badge demo

### DIFF
--- a/app/dashboard/sonic_dashboard.html
+++ b/app/dashboard/sonic_dashboard.html
@@ -3,9 +3,11 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_content_container.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 {% endblock %}
 
 {% block content %}
+  {% include "title_bar.html" %}
   <div class="sonic-content-panel">
     <div style="margin:auto;padding:3rem;font-size:2rem;">Hello from the new Sonic Dashboard!</div>
   </div>

--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -227,9 +227,10 @@ def test_desktop_dashboard():
             "size": {"low": 1000, "medium": 5000, "high": 10000},
             "ratio": {"low": 1.1, "medium": 1.5, "high": 2.0},
             "travel": {"low": -10.0, "medium": -5.0, "high": 0.0},
-        }
+        },
+        "profit_badge_value": 123
     }
-    return render_template("dashboard.html", **mock_context)
+    return render_template("sonic_dashboard.html", **mock_context)
 
 @dashboard_bp.route("/api/dashboard_cards", methods=["GET"])
 def api_dashboard_cards():

--- a/tests/test_dashboard_profit_badge.py
+++ b/tests/test_dashboard_profit_badge.py
@@ -1,0 +1,19 @@
+import pytest
+from flask import Flask
+from app.dashboard_bp import dashboard_bp
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(dashboard_bp)
+    with app.test_client() as client:
+        yield client
+
+def test_profit_badge_in_test_dashboard(client):
+    response = client.get("/test/desktop")
+    assert response.status_code == 200
+    html = response.data.decode()
+    assert "profit-badge" in html
+    assert "123" in html
+


### PR DESCRIPTION
## Summary
- show profit badge on test dashboard route
- allow Sonic dashboard template to render title bar for testing
- add test checking profit badge appears on the canned dashboard

## Testing
- `pytest -k test_dashboard_profit_badge -q` *(fails: ModuleNotFoundError: No module named 'alerts')*