### PR TITLE
Add hedge pair slider to Hedge Labs

### DIFF
--- a/static/js/hedge_labs.js
+++ b/static/js/hedge_labs.js
@@ -19,6 +19,64 @@ function postAction(url) {
     .then(() => loadHedges());
 }
 
+let currentHedgeId = null;
+let hedgePositions = [];
+
+function loadHedgePositions(id) {
+  fetch(`/sonic_labs/api/hedge_positions?hedge_id=${id}`)
+    .then(resp => resp.json())
+    .then(data => {
+      hedgePositions = data.positions || [];
+      initSlider();
+      updateEvaluation();
+    });
+}
+
+function initSlider() {
+  const slider = document.getElementById('priceSlider');
+  if (!slider || hedgePositions.length === 0) return;
+  slider.disabled = false;
+  const long = hedgePositions.find(p => (p.position_type || '').toUpperCase() === 'LONG') || {};
+  const short = hedgePositions.find(p => (p.position_type || '').toUpperCase() === 'SHORT') || {};
+  const longLiq = parseFloat(long.liquidation_price) || 0;
+  const shortLiq = parseFloat(short.liquidation_price) || 0;
+  const longEntry = parseFloat(long.entry_price) || 0;
+  const shortEntry = parseFloat(short.entry_price) || 0;
+  const current = longEntry && shortEntry ? (longEntry + shortEntry) / 2 : longEntry || shortEntry || 0;
+  slider.min = longLiq ? longLiq * 0.95 : current * 0.8;
+  slider.max = shortLiq ? shortLiq * 1.05 : current * 1.2;
+  slider.value = current;
+  document.getElementById('priceValue').textContent = 'Price: $' + current.toFixed(2);
+}
+
+function updateEvaluation() {
+  const slider = document.getElementById('priceSlider');
+  if (!slider || !currentHedgeId) return;
+  const price = parseFloat(slider.value);
+  document.getElementById('priceValue').textContent = 'Price: $' + price.toFixed(2);
+  fetch(`/sonic_labs/api/evaluate_hedge?hedge_id=${currentHedgeId}&price=${price}`)
+    .then(resp => resp.json())
+    .then(data => updateTable(data));
+}
+
+function updateTable(data) {
+  const body = document.querySelector('#evalTable tbody');
+  if (!body) return;
+  body.innerHTML = '';
+  ['long', 'short'].forEach(type => {
+    const row = data[type];
+    if (!row) return;
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${type}</td><td>${row.value}</td><td>${row.travel_percent}</td><td>${row.heat_index}</td>`;
+    body.appendChild(tr);
+  });
+  if (data.totals) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<th>Total</th><th>${data.totals.total_value}</th><th>${data.totals.avg_travel_percent.toFixed(2)}</th><th>${data.totals.avg_heat_index.toFixed(2)}</th>`;
+    body.appendChild(tr);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   loadHedges();
   const linkBtn = document.getElementById('linkHedgesBtn');
@@ -31,4 +89,16 @@ document.addEventListener('DOMContentLoaded', () => {
       console.log('Calc Totals', res);
     });
   });
+
+  const select = document.getElementById('hedgeSelect');
+  const slider = document.getElementById('priceSlider');
+  if (select) {
+    select.addEventListener('change', () => {
+      currentHedgeId = select.value;
+      if (currentHedgeId) loadHedgePositions(currentHedgeId);
+    });
+  }
+  if (slider) {
+    slider.addEventListener('input', updateEvaluation);
+  }
 });

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -35,6 +35,41 @@
       {% endfor %}
     </tbody>
   </table>
+
+  <div class="card mt-4">
+    <div class="card-body">
+      <div class="row mb-3">
+        <div class="col-md-4">
+          <label for="hedgeSelect" class="form-label"><strong>Select Hedge</strong></label>
+          <select id="hedgeSelect" class="form-select">
+            <option value="" disabled selected>-- Choose Hedge --</option>
+            {% for h in hedges %}
+            <option value="{{ h.id }}">{{ h.id }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-md-8">
+          <label for="priceSlider" class="form-label"><strong>Simulated Price</strong></label>
+          <input type="range" id="priceSlider" class="form-range" step="0.01" disabled>
+          <div id="priceValue" class="mt-2">Price: 0</div>
+        </div>
+      </div>
+      <table class="table table-sm" id="evalTable">
+        <thead>
+          <tr>
+            <th>Position</th>
+            <th>Value</th>
+            <th>Travel %</th>
+            <th>Heat</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <script>
+    window.initialHedges = {{ hedges | tojson }};
+  </script>
 </div>
 {% endblock %}
 

--- a/tests/test_hedge_eval_api.py
+++ b/tests/test_hedge_eval_api.py
@@ -1,0 +1,71 @@
+import pytest
+from flask import Flask
+from sonic_labs.sonic_labs_bp import sonic_labs_bp
+from data.models import Hedge
+
+class MockPositions:
+    def __init__(self):
+        self.data = {
+            "long1": {
+                "id": "long1",
+                "position_type": "LONG",
+                "entry_price": 100.0,
+                "liquidation_price": 50.0,
+                "size": 1.0,
+                "collateral": 100.0,
+                "leverage": 1.0,
+                "current_price": 100.0,
+            },
+            "short1": {
+                "id": "short1",
+                "position_type": "SHORT",
+                "entry_price": 110.0,
+                "liquidation_price": 160.0,
+                "size": 1.0,
+                "collateral": 100.0,
+                "leverage": 1.0,
+                "current_price": 110.0,
+            },
+        }
+
+    def get_position_by_id(self, pid):
+        return self.data.get(pid)
+
+class MockHedges:
+    def get_hedges(self):
+        h = Hedge(id="h1", positions=["long1", "short1"])
+        return [h]
+
+class MockSystem:
+    def get_active_theme_profile(self):
+        return {}
+
+class MockModifiers:
+    def get_all_modifiers(self, group):
+        return {}
+
+class MockDataLocker:
+    def __init__(self):
+        self.positions = MockPositions()
+        self.hedges = MockHedges()
+        self.system = MockSystem()
+        self.modifiers = MockModifiers()
+
+def make_client():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.data_locker = MockDataLocker()
+    app.register_blueprint(sonic_labs_bp, url_prefix="/sonic_labs")
+    return app.test_client()
+
+
+def test_evaluate_hedge_endpoint():
+    client = make_client()
+    resp = client.get("/sonic_labs/api/evaluate_hedge", query_string={"hedge_id": "h1", "price": "120"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "long" in data and "short" in data
+    assert data["long"]["id"] == "long1"
+    assert data["short"]["id"] == "short1"
+
+


### PR DESCRIPTION
## Summary
- allow selecting hedges and evaluating them at a simulated price
- expose `/api/hedge_positions` and `/api/evaluate_hedge` endpoints
- add slider, dropdown and result table to Hedge Labs page
- update JavaScript to drive new UI
- add unit test for evaluation endpoint

## Testing
- `pytest tests/test_hedge_eval_api.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*