### PR TITLE
Remove extra title bar icons

### DIFF
--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -6,10 +6,7 @@
     <a class="btn btn-light nav-icon-btn" href="/hedge_calculator" title="Hedge Calculator"><span>🌿</span></a>
     <a class="btn btn-light nav-icon-btn" href="/sonic_labs/hedge_labs" title="Hedge Labs"><span>🧪</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/status_page" title="Alert Status"><span>🚨</span></a>
-    <a class="btn btn-light nav-icon-btn" href="/alerts/status_page" title="Alert Status"><span>🎛️</span></a>
-
     <a class="btn btn-light nav-icon-btn" href="/sonic_labs/hedge_report" title="Hedge Report"><span>🦔</span></a>
-    <a class="btn btn-light nav-icon-btn" href="/system/xcom_config" title="XCom Config"><span>🔌</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
     <div id="refreshDial" class="refresh-dial" title="UI auto-refresh">


### PR DESCRIPTION
## Summary
- trim down icon row in the title bar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*