### PR TITLE
Quiet startup logs

### DIFF
--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -55,7 +55,7 @@ class DataLocker:
         self.initialize_database()
         self._seed_modifiers_if_empty()
 
-        log.info("All DL managers bootstrapped successfully.", source="DataLocker")
+        log.debug("All DL managers bootstrapped successfully.", source="DataLocker")
 
     def initialize_database(self):
         """
@@ -215,7 +215,7 @@ class DataLocker:
         for name, ddl in table_defs.items():
             try:
                 cursor.execute(ddl)
-                log.success(f"✅ Table ensured: {name}", source="DataLocker")
+                log.debug(f"Table ensured: {name}", source="DataLocker")
             except Exception as e:
                 log.error(f"❌ Failed creating table {name}: {e}", source="DataLocker")
 
@@ -236,7 +236,7 @@ class DataLocker:
 
     def close(self):
         self.db.close()  # Hey
-        log.info("DataLocker shutdown complete.", source="DataLocker")
+        log.debug("DataLocker shutdown complete.", source="DataLocker")
 
     def get_latest_price(self, asset_type: str) -> dict:
         return self.prices.get_latest_price(asset_type)
@@ -316,7 +316,7 @@ class DataLocker:
                 with open(SONIC_SAUCE_PATH, "r", encoding="utf-8") as f:
                     data = f.read()
                 self.modifiers.import_from_json(data)
-                log.success("📦 Modifiers seeded from sonic_sauce.json", source="DataLocker")
+                log.debug("Modifiers seeded from sonic_sauce.json", source="DataLocker")
             except Exception as e:
                 log.error(f"❌ Failed seeding modifiers: {e}", source="DataLocker")
 

--- a/data/dl_alerts.py
+++ b/data/dl_alerts.py
@@ -20,7 +20,7 @@ Dependencies:
 class DLAlertManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLAlertManager initialized.", source="DLAlertManager")
+        log.debug("DLAlertManager initialized.", source="DLAlertManager")
 
     def create_alert(self, alert: dict) -> bool:
         try:

--- a/data/dl_brokers.py
+++ b/data/dl_brokers.py
@@ -16,7 +16,7 @@ Dependencies:
 class DLBrokerManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLBrokerManager initialized.", source="DLBrokerManager")
+        log.debug("DLBrokerManager initialized.", source="DLBrokerManager")
 
     def create_broker(self, broker: dict):
         try:

--- a/data/dl_hedges.py
+++ b/data/dl_hedges.py
@@ -20,7 +20,7 @@ from core.core_imports import log
 class DLHedgeManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLHedgeManager initialized.", source="DLHedgeManager")
+        log.debug("DLHedgeManager initialized.", source="DLHedgeManager")
 
     def get_hedges(self) -> list:
         """Return a list of :class:`Hedge` objects from existing positions."""

--- a/data/dl_modifiers.py
+++ b/data/dl_modifiers.py
@@ -5,7 +5,7 @@ from core.logging import log
 class DLModifierManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLModifierManager initialized.", source="DLModifierManager")
+        log.debug("DLModifierManager initialized.", source="DLModifierManager")
 
     def ensure_table(self):
         cursor = self.db.get_cursor()
@@ -18,7 +18,7 @@ class DLModifierManager:
             )
         """)
         self.db.commit()
-        log.success("✅ modifiers table ensured", source="DLModifierManager")
+        log.debug("modifiers table ensured", source="DLModifierManager")
 
     def set_modifier(self, key: str, value: float, group: str = "heat_modifiers"):
         cursor = self.db.get_cursor()

--- a/data/dl_monitor_ledger.py
+++ b/data/dl_monitor_ledger.py
@@ -26,7 +26,7 @@ class DLMonitorLedgerManager:
             )
         """)
         self.db.commit()
-        log.success("✅ monitor_ledger table ensured", source="DLMonitorLedger")
+        log.debug("monitor_ledger table ensured", source="DLMonitorLedger")
 
     def insert_ledger_entry(self, monitor_name: str, status: str, metadata: dict = None):
         import uuid

--- a/data/dl_portfolio.py
+++ b/data/dl_portfolio.py
@@ -18,7 +18,7 @@ from core.core_imports import log
 class DLPortfolioManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLPortfolioManager initialized.", source="DLPortfolioManager")
+        log.debug("DLPortfolioManager initialized.", source="DLPortfolioManager")
 
     def record_snapshot(self, totals: dict):
         try:

--- a/data/dl_positions.py
+++ b/data/dl_positions.py
@@ -21,7 +21,7 @@ from core.core_imports import log
 class DLPositionManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLPositionManager initialized.", source="DLPositionManager")
+        log.debug("DLPositionManager initialized.", source="DLPositionManager")
 
     def create_position(self, position: dict):
         from datetime import datetime

--- a/data/dl_prices.py
+++ b/data/dl_prices.py
@@ -6,7 +6,7 @@ from core.core_imports import log
 class DLPriceManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLPriceManager initialized.", source="DLPriceManager")
+        log.debug("DLPriceManager initialized.", source="DLPriceManager")
 
     def insert_price(self, price_data: dict):
         try:

--- a/data/dl_system_data.py
+++ b/data/dl_system_data.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 class DLSystemDataManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLSystemDataManager initialized.", source="DLSystemDataManager")
+        log.debug("DLSystemDataManager initialized.", source="DLSystemDataManager")
 
     # === Theme Mode ===
     def get_theme_mode(self) -> str:

--- a/data/dl_thresholds.py
+++ b/data/dl_thresholds.py
@@ -11,7 +11,7 @@ from datetime import datetime
 class DLThresholdManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLThresholdManager initialized.", source="DLThresholdManager")
+        log.debug("DLThresholdManager initialized.", source="DLThresholdManager")
 
     def get_all(self) -> list:
         cursor = self.db.get_cursor()

--- a/data/dl_wallets.py
+++ b/data/dl_wallets.py
@@ -19,7 +19,7 @@ from wallets.encryption import encrypt_key, decrypt_key
 class DLWalletManager:
     def __init__(self, db):
         self.db = db
-        log.info("DLWalletManager initialized.", source="DLWalletManager")
+        log.debug("DLWalletManager initialized.", source="DLWalletManager")
 
     def create_wallet(self, wallet: dict):
         try:


### PR DESCRIPTION
## Summary
- downgrade initialization logs for DataLocker modules
- keep table creation messages hidden unless debug is enabled

## Testing
- `pytest -q` *(fails: ImportError: No module named 'alerts.threshold_service')*