### PR TITLE
Clean up DataLocker stub

### DIFF
--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -27,12 +27,6 @@ from data.dl_monitor_ledger import DLMonitorLedgerManager
 from data.dl_modifiers import DLModifierManager
 from data.dl_hedges import DLHedgeManager
 from core.constants import SONIC_SAUCE_PATH
-
-class DataLocker:
-    def __init__(self, db_path):
-        ...
-        self.ledger = DLMonitorLedgerManager(self.db)
-
 from core.core_imports import log
 from datetime import datetime
 


### PR DESCRIPTION
## Summary
- remove leftover stub DataLocker class
- place logging imports with the rest

## Testing
- `python - <<'PY' ...` (imported `DataLocker` with stub `rich` module)
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts', ...)*