### PR TITLE
Remove circle from settings icon

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -202,10 +202,4 @@
   font-weight: 600;
 }
 
-/* Make the settings icon circular */
-#settingsDropdown.nav-icon-btn {
-  width: 48px;
-  height: 48px;
-  padding: 0;
-  border-radius: 50%;
-}
+

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -36,7 +36,7 @@
         <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="wipe"  title="Wipe All"><span>🗑️</span></a>
       </div>
     <div class="dropdown ms-3">
-      <a class="btn btn-light nav-icon-btn dropdown-toggle" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">
+      <a class="btn config-btn dropdown-toggle" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">
         <span>⚙️</span>
       </a>
       <ul class="dropdown-menu" aria-labelledby="settingsDropdown">


### PR DESCRIPTION
## Summary
- tweak title bar settings dropdown to use icon style
- remove CSS rule that forced circular settings button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alerts')*