### PR TITLE
Update db_path in config

### DIFF
--- a/config/sonic_config.json
+++ b/config/sonic_config.json
@@ -13,7 +13,7 @@
     "log_level": "DEBUG",
     "console_output": true,
     "log_file": "./v0.7/price_monitor.log",
-    "db_path": "./v0.7/mother_brain.db",
+    "db_path": "./data/mother_brain.db",
     "price_monitor_enabled": true,
     "alert_monitor_enabled": true,
     "sonic_monitor_loop_time": 300,


### PR DESCRIPTION
## Summary
- update db path in `sonic_config.json` to use data directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*