### PR TITLE
Implement run_position_updates

### DIFF
--- a/cyclone/cyclone_engine.py
+++ b/cyclone/cyclone_engine.py
@@ -101,6 +101,15 @@ class Cyclone:
         except Exception as e:
             log.error(f"📉 Market Updates crashed: {e}", source="Cyclone")
 
+    async def run_position_updates(self):
+        """Sync positions from Jupiter wallets."""
+        log.info("Starting Position Updates", source="Cyclone")
+        try:
+            await asyncio.to_thread(self.position_core.update_positions_from_jupiter)
+            log.success("🪐 Position updates completed", source="Cyclone")
+        except Exception as e:
+            log.error(f"Position Updates crashed: {e}", source="Cyclone")
+
     async def run_composite_position_pipeline(self):
         await asyncio.to_thread(self.position_core.update_positions_from_jupiter)
 


### PR DESCRIPTION
## Summary
- implement `run_position_updates` in `Cyclone` engine so /cyclone/run_position_updates works

## Testing
- `pytest -q tests/test_cyclone_position_updates.py` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*
- `flake8` *(fails: command not found)*