### PR TITLE
Fix hedge labs slider evaluation

### DIFF
--- a/FULL_SPEC.md
+++ b/FULL_SPEC.md
@@ -1255,6 +1255,7 @@ HedgeCore(data_locker)
 - All logging is handled through the shared logger injected via `core.core_imports`. 【F:hedge_core/hedge_core.py†L24-L129】
 - Hedge detection relies solely on wallet/asset pairs and does not consider leverage or size weighting in this implementation.
 - `get_modifiers()` provides a simple pass-through to the data layer so external callers can inspect weighting factors.
+- Hedge IDs mirror the `hedge_buddy_id` used to link positions ensuring stable lookups across API calls.
 
 \n---\n
 # File: monitor/monitor_module_spec.md

--- a/hedge_core/hedge_core.py
+++ b/hedge_core/hedge_core.py
@@ -41,7 +41,11 @@ class HedgeCore:
             return []
 
     def build_hedges(self, positions: Optional[List[dict]] = None) -> List[Hedge]:
-        """Build :class:`Hedge` objects from position records."""
+        """Build :class:`Hedge` objects from position records.
+
+        The returned hedge ID now matches the ``hedge_buddy_id`` used to link
+        positions so that consecutive calls yield consistent identifiers.
+        """
         if positions is None:
             positions = self.dl.positions.get_all_positions()
 
@@ -55,7 +59,8 @@ class HedgeCore:
         for key, group in hedge_groups.items():
             if len(group) < 2:
                 continue
-            hedge = Hedge(id=str(uuid4()))
+            # Use the hedge_buddy_id as the Hedge ID so lookups remain stable
+            hedge = Hedge(id=str(key))
             hedge.positions = [p.get("id") for p in group]
 
             total_long = total_short = long_heat = short_heat = 0.0

--- a/hedge_core/hedge_core_module_spec.md
+++ b/hedge_core/hedge_core_module_spec.md
@@ -38,5 +38,6 @@ HedgeCore(data_locker)
 ### ✅ Design Notes
 - All logging is handled through the shared logger injected via `core.core_imports`. 【F:hedge_core/hedge_core.py†L24-L129】
 - Hedge detection relies solely on wallet/asset pairs and does not consider leverage or size weighting in this implementation.
+- Hedge IDs are set to the `hedge_buddy_id` so they remain consistent between calls.
 - `get_modifiers()` provides a simple pass-through to the data layer so external callers can inspect weighting factors.
 

--- a/static/js/hedge_labs.js
+++ b/static/js/hedge_labs.js
@@ -42,7 +42,12 @@ function initSlider() {
   const shortLiq = parseFloat(short.liquidation_price) || 0;
   const longEntry = parseFloat(long.entry_price) || 0;
   const shortEntry = parseFloat(short.entry_price) || 0;
-  const current = longEntry && shortEntry ? (longEntry + shortEntry) / 2 : longEntry || shortEntry || 0;
+  const longCurrent = parseFloat(long.current_price) || longEntry;
+  const shortCurrent = parseFloat(short.current_price) || shortEntry;
+  const current =
+    longCurrent && shortCurrent
+      ? (longCurrent + shortCurrent) / 2
+      : longCurrent || shortCurrent || 0;
   slider.min = longLiq ? longLiq * 0.95 : current * 0.8;
   slider.max = shortLiq ? shortLiq * 1.05 : current * 1.2;
   slider.value = current;
@@ -67,7 +72,10 @@ function updateTable(data) {
     const row = data[type];
     if (!row) return;
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${type}</td><td>${row.value}</td><td>${row.travel_percent}</td><td>${row.heat_index}</td>`;
+    const value = typeof row.value === 'number' ? row.value.toFixed(2) : row.value;
+    const travel = typeof row.travel_percent === 'number' ? row.travel_percent.toFixed(2) : row.travel_percent;
+    const heat = typeof row.heat_index === 'number' ? row.heat_index.toFixed(2) : row.heat_index;
+    tr.innerHTML = `<td>${type}</td><td>${value}</td><td>${travel}</td><td>${heat}</td>`;
     body.appendChild(tr);
   });
   if (data.totals) {


### PR DESCRIPTION
## Summary
- default price slider to the current price of hedge positions
- format evaluation table values consistently
- use hedge_buddy_id as the stable hedge ID

## Testing
- `pytest tests/test_hedge_eval_api.py tests/test_hedge_calculator_page.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*
