### PR TITLE
Fix apply_color threshold handling

### DIFF
--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -83,20 +83,24 @@ def apply_color(metric_name: str, value: float, thresholds: dict) -> str:
             return "red"
 
         val = float(value)
-        cond = thresholds.get("condition", "ABOVE").upper()
+        cond = str(thresholds.get("condition", "ABOVE")).upper()
+
+        high = thresholds.get("high")
+        med = thresholds.get("medium")
+        low = thresholds.get("low")
 
         if cond == "ABOVE":
-            return (
-                "red" if val >= thresholds["high"] else
-                "yellow" if val >= thresholds["medium"] else
-                "green"
-            )
+            if high is not None and val >= float(high):
+                return "red"
+            if med is not None and val >= float(med):
+                return "yellow"
+            return "green"
         elif cond == "BELOW":
-            return (
-                "red" if val <= thresholds["low"] else
-                "yellow" if val <= thresholds["medium"] else
-                "green"
-            )
+            if low is not None and val <= float(low):
+                return "red"
+            if med is not None and val <= float(med):
+                return "yellow"
+            return "green"
         else:
             return "green"
 

--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -80,18 +80,22 @@ def apply_color(metric_name, value, limits):
         val = float(value)
         cond = str(thresholds.get("condition", "ABOVE")).upper()
 
+        high = thresholds.get("high")
+        med = thresholds.get("medium")
+        low = thresholds.get("low")
+
         if cond == "ABOVE":
-            return (
-                "red" if val >= thresholds.get("high") else
-                "yellow" if val >= thresholds.get("medium") else
-                "green"
-            )
+            if high is not None and val >= float(high):
+                return "red"
+            if med is not None and val >= float(med):
+                return "yellow"
+            return "green"
         elif cond == "BELOW":
-            return (
-                "red" if val <= thresholds.get("low") else
-                "yellow" if val <= thresholds.get("medium") else
-                "green"
-            )
+            if low is not None and val <= float(low):
+                return "red"
+            if med is not None and val <= float(med):
+                return "yellow"
+            return "green"
         else:
             return "green"
 


### PR DESCRIPTION
## Summary
- avoid errors when threshold values are `None`
- guard comparisons in both dashboard utility modules

## Testing
- `pytest -q tests/test_dashboard_profit_badge.py::test_profit_badge_calculation -q` *(fails: ModuleNotFoundError: No module named 'flask')*