### PR TITLE
Fix imports and DB setup in StartUpCheck

### DIFF
--- a/utils/start_up_check.py
+++ b/utils/start_up_check.py
@@ -1,9 +1,25 @@
 from core.constants import (
-    DB_PATH, CONFIG_PATH, ALERT_LIMITS_PATH, BASE_DIR
+    DB_PATH,
+    CONFIG_PATH,
+    ALERT_LIMITS_PATH,
+    BASE_DIR,
 )
-#from utils.path_audit import maybe_create_mother_brain
+# from utils.path_audit import maybe_create_mother_brain
 import os
 from pathlib import Path
+import sqlite3
+
+from utils.config_loader import save_config
+from core.core_imports import log
+
+
+def maybe_create_mother_brain(db_path: str) -> None:
+    """Ensure the SQLite database file exists."""
+    if not os.path.exists(db_path):
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.close()
+        log.info(f"📄 Created database: {db_path}", source="StartUpCheck")
 
 class StartUpCheck:
 
@@ -47,8 +63,6 @@ class StartUpCheck:
                     "thresholds": {}
                 }
             }
-from utils.config_loader import save_config
-from core.core_imports import log
             save_config("alert_limitsz.json", default)
             log.success("✅ Default alert_limitsz.json created.", source="StartUpCheck")
         else:


### PR DESCRIPTION
## Summary
- reorder imports in `start_up_check.py`
- add a helper to create the database if missing
- invoke the correct class in the main block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*