### PR TITLE
Add Twilio heartbeat service and monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ TWILIO_TO_PHONE=+1234567890
 TWILIO_FLOW_SID=your_flow_sid_here
 ```
 
+## Twilio Monitor
+
+The `twilio_monitor` runs as part of the background monitor suite. It uses
+`CheckTwilioHeartbeartService` in dry‑run mode to verify that credentials are
+valid without placing an actual call.
+
 ## Hedge Calculator
 
 ## Threshold Seeder

--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -58,7 +58,10 @@ def test_xcom():
         elif mode == "email":
             xcom.send_notification("LOW", "Test Email", msg)
         elif mode == "voice":
-            xcom.send_notification("HIGH", "Test Voice", msg)
+            from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+
+            twilio_cfg = xcom.config_service.get_provider("twilio") or {}
+            CheckTwilioHeartbeartService(twilio_cfg).check(dry_run=False)
         elif mode == "system":
             SoundService().play()
 

--- a/monitor/monitor_core.py
+++ b/monitor/monitor_core.py
@@ -8,6 +8,7 @@ from monitor.price_monitor import PriceMonitor
 from monitor.position_monitor import PositionMonitor
 from monitor.operations_monitor import OperationsMonitor
 from monitor.xcom_monitor import XComMonitor
+from monitor.twilio_monitor import TwilioMonitor
 # Add any new monitors here
 
 from monitor.monitor_registry import MonitorRegistry
@@ -23,6 +24,7 @@ class MonitorCore:
         self.registry.register("position_monitor", PositionMonitor())
         self.registry.register("operations_monitor", OperationsMonitor())
         self.registry.register("xcom_monitor", XComMonitor())
+        self.registry.register("twilio_monitor", TwilioMonitor())
         # Add more monitors as needed
 
     def run_all(self):

--- a/monitor/twilio_monitor.py
+++ b/monitor/twilio_monitor.py
@@ -1,0 +1,25 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from monitor.base_monitor import BaseMonitor
+from data.data_locker import DataLocker
+from xcom.xcom_config_service import XComConfigService
+from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+from core.core_imports import DB_PATH
+
+
+class TwilioMonitor(BaseMonitor):
+    """Heartbeat monitor to verify Twilio credentials."""
+
+    def __init__(self):
+        super().__init__(name="twilio_monitor", ledger_filename="twilio_ledger.json")
+        self.dl = DataLocker(str(DB_PATH))
+        self.config_service = XComConfigService(self.dl.system)
+
+    def _do_work(self):
+        cfg = self.config_service.get_provider("twilio") or {}
+        service = CheckTwilioHeartbeartService(cfg)
+        result = service.check(dry_run=True)
+        return result
+

--- a/xcom/check_twilio_heartbeart_service.py
+++ b/xcom/check_twilio_heartbeart_service.py
@@ -1,0 +1,53 @@
+import os
+from typing import Dict
+
+from flask import current_app
+from twilio.rest import Client
+
+from core.logging import log
+from .voice_service import VoiceService
+
+
+class CheckTwilioHeartbeartService:
+    """Verify Twilio credentials and optionally place a test voice call."""
+
+    def __init__(self, config: Dict):
+        self.config = config or {}
+
+    def _load_creds(self):
+        account_sid = self.config.get("account_sid") or os.getenv("TWILIO_ACCOUNT_SID")
+        auth_token = self.config.get("auth_token") or os.getenv("TWILIO_AUTH_TOKEN")
+        from_phone = self.config.get("default_from_phone") or os.getenv("TWILIO_FROM_PHONE")
+        to_phone = self.config.get("default_to_phone") or os.getenv("TWILIO_TO_PHONE")
+        return account_sid, auth_token, from_phone, to_phone
+
+    def check(self, dry_run: bool = True) -> Dict:
+        """Return dict with success status and whether a call was placed."""
+        result = {"success": False, "call_placed": False}
+        account_sid, auth_token, from_phone, to_phone = self._load_creds()
+        try:
+            if not account_sid or not auth_token:
+                raise Exception("Missing Twilio credentials")
+
+            client = Client(account_sid, auth_token)
+            client.api.accounts(account_sid).fetch()
+
+            if not dry_run:
+                if not from_phone or not to_phone:
+                    raise Exception("Missing from/to phone numbers")
+                VoiceService(self.config).call(to_phone, "XCom heartbeat check")
+                result["call_placed"] = True
+
+            result["success"] = True
+        except Exception as exc:
+            log.error(f"Twilio heartbeat failed: {exc}", source="CheckTwilioHeartbeatService")
+            if hasattr(current_app, "system_core"):
+                current_app.system_core.death(
+                    {
+                        "message": f"Twilio heartbeat failure: {exc}",
+                        "payload": {"provider": "twilio"},
+                        "level": "HIGH",
+                    }
+                )
+            result["error"] = str(exc)
+        return result


### PR DESCRIPTION
## Summary
- add `CheckTwilioHeartbeartService` for Twilio credential checks
- call new service from XCom "Trigger Voice Call" test
- implement `TwilioMonitor` for dry-run health checks
- register the monitor in `MonitorCore`
- document Twilio monitor in README

## Testing
- `pytest -k twilio -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*