### PR TITLE
Add position type indicator to alerts

### DIFF
--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -50,7 +50,13 @@
           {% if alerts %}
             {% for alert in alerts %}
             <tr data-alert-id="{{ alert.id }}">
-              <td class="left"><img class="asset-icon" src="{{ url_for('static', filename='images/' + alert.asset_image) }}" alt="{{ alert.asset }}"><span style="display:none">{{ alert.asset or 'N/A' }}</span></td>
+              <td class="left">
+                <span class="icon-inline">
+                  <img class="asset-icon" src="{{ url_for('static', filename='images/' + alert.asset_image) }}" alt="{{ alert.asset }}">
+                  {{ alert.asset or 'N/A' }}{% if alert.position_type %} ({{ alert.position_type|title }}){% endif %}
+                </span>
+                <span style="display:none">{{ alert.asset or 'N/A' }}</span>
+              </td>
               <td class="left">{{ type_icons.get(alert.alert_type|lower, '❓') }}</td>
               <td class="left">{{ alert.alert_class }}</td>
               <td class="right">{{ "{:,.2f}".format(alert.evaluated_value or 0) }}</td>


### PR DESCRIPTION
## Summary
- show position side beside the asset icon on the alert status page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*