### PR TITLE
Add profit badge helper and context injection

### DIFF
--- a/sonic_app.py
+++ b/sonic_app.py
@@ -17,6 +17,7 @@ from flask_socketio import SocketIO
 from core.core_imports import log, configure_console_log, DB_PATH, BASE_DIR, retry_on_locked
 from data.data_locker import DataLocker
 from system.system_core import SystemCore
+from dashboard.dashboard_service import get_profit_badge_value
 
 # --- Monitor & Cyclone Core Integration ---
 from monitor.monitor_core import MonitorCore
@@ -123,6 +124,15 @@ def inject_theme_profile():
         return {"active_theme_profile": active_theme or {}}
     except Exception:
         return {"active_theme_profile": {}}
+
+# --- Context: Profit Badge ---
+@app.context_processor
+def inject_profit_badge():
+    try:
+        value = get_profit_badge_value(current_app.data_locker, current_app.system_core)
+        return {"profit_badge_value": value}
+    except Exception:
+        return {"profit_badge_value": None}
 
 # --- Server Entry Point ---
 if __name__ == "__main__":

--- a/tests/test_profit_badge_routes.py
+++ b/tests/test_profit_badge_routes.py
@@ -1,0 +1,61 @@
+import pytest
+from flask import Flask, render_template
+
+from app.dashboard_bp import dashboard_bp
+from app.alerts_bp import alerts_bp
+from app.system_bp import system_bp
+from dashboard import dashboard_service
+
+@pytest.fixture
+def client(monkeypatch):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(dashboard_bp)
+    app.register_blueprint(alerts_bp, url_prefix="/alerts")
+    app.register_blueprint(system_bp, url_prefix="/system")
+
+    # Simplify heavy view logic
+    app.view_functions["alerts.alert_status_page"] = lambda: render_template("alert_status.html", alerts=[])
+    app.view_functions["system.hedge_calculator_page"] = lambda: render_template(
+        "hedge_calculator.html",
+        theme={},
+        long_positions=[],
+        short_positions=[],
+        modifiers={},
+        default_long_id=None,
+        default_short_id=None,
+    )
+
+    app.data_locker = object()
+    app.system_core = object()
+
+    monkeypatch.setattr(dashboard_service, "get_profit_badge_value", lambda dl, sc: 42)
+
+    @app.context_processor
+    def inject_profit_badge():
+        value = dashboard_service.get_profit_badge_value(app.data_locker, app.system_core)
+        return {"profit_badge_value": value}
+
+    with app.test_client() as client:
+        yield client
+
+def test_badge_on_new_dashboard(client):
+    resp = client.get("/new_dashboard")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert "profit-badge" in html
+    assert "42" in html
+
+def test_badge_on_hedge_calculator(client):
+    resp = client.get("/system/hedge_calculator")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert "profit-badge" in html
+    assert "42" in html
+
+def test_badge_on_alert_status(client):
+    resp = client.get("/alerts/status_page")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert "profit-badge" in html
+    assert "42" in html


### PR DESCRIPTION
## Summary
- compute profit badge via `get_profit_badge_value`
- expose badge value via new `inject_profit_badge` context processor
- use helper in dashboard context
- test pages using `title_bar.html` render profit badge

## Testing
- `pytest tests/test_dashboard_profit_badge.py tests/test_profit_badge_routes.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*