### PR TITLE
Fix alert threshold save flow

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -626,6 +626,31 @@ def update_alert_threshold(id):
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+# === POST: Update all thresholds ===
+@system_bp.route("/alert_thresholds/update_all", methods=["POST"])
+def update_all_alert_thresholds():
+    try:
+        payload = request.get_json(force=True)
+        if not isinstance(payload, list):
+            return (
+                jsonify({"success": False, "error": "Expected a list of thresholds"}),
+                400,
+            )
+
+        db = current_app.data_locker.db
+        dl_mgr = DLThresholdManager(db)
+        updated = 0
+        for item in payload:
+            tid = item.get("id")
+            if not tid:
+                continue
+            dl_mgr.update(tid, item)
+            updated += 1
+        return jsonify({"success": True, "updated": updated})
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
 @system_bp.route("/alert_thresholds/export", methods=["GET"])
 def export_alert_thresholds():
     db = current_app.data_locker.db

--- a/data/dl_thresholds.py
+++ b/data/dl_thresholds.py
@@ -52,6 +52,14 @@ class DLThresholdManager:
                 if k in fields and isinstance(fields[k], list):
                     fields[k] = ",".join(fields[k])
 
+            # Filter out fields not present in DB schema
+            cursor = self.db.get_cursor()
+            cols = getattr(self, "_cols", None)
+            if cols is None:
+                cols = {row[1] for row in cursor.execute("PRAGMA table_info(alert_thresholds)")}
+                self._cols = cols
+            fields = {k: v for k, v in fields.items() if k in cols}
+
             # Set last_modified
             fields["last_modified"] = datetime.now(timezone.utc).isoformat()
             fields["id"] = threshold_id

--- a/static/js/alert_thresholds.js
+++ b/static/js/alert_thresholds.js
@@ -1,37 +1,43 @@
 window.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.save-threshold').forEach(btn => {
-    btn.addEventListener('click', async evt => {
-      evt.preventDefault();
-      const row = btn.closest('tr');
-      const id = row.dataset.id;
-      const payload = {
-        low: parseFloat(row.querySelector('[name="low"]').value) || 0,
-        medium: parseFloat(row.querySelector('[name="medium"]').value) || 0,
-        high: parseFloat(row.querySelector('[name="high"]').value) || 0,
-        enabled: row.querySelector('[name="enabled"]').checked,
-        low_notify: Array.from(row.querySelectorAll('[name="low_notify"]:checked')).map(el => el.value),
-        medium_notify: Array.from(row.querySelectorAll('[name="medium_notify"]:checked')).map(el => el.value),
-        high_notify: Array.from(row.querySelectorAll('[name="high_notify"]:checked')).map(el => el.value)
-      };
-      try {
-        const resp = await fetch(`/system/alert_thresholds/update/${id}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
-        if (resp.ok) {
-          btn.classList.remove('btn-primary');
-          btn.classList.add('btn-success');
-          setTimeout(() => {
-            btn.classList.remove('btn-success');
-            btn.classList.add('btn-primary');
-          }, 1000);
-        } else {
-          alert('Failed to save threshold');
+  const saveBtn = document.getElementById('saveAllThresholds');
+  if (!saveBtn) return;
+
+  saveBtn.addEventListener('click', async evt => {
+    evt.preventDefault();
+
+    const rows = document.querySelectorAll('tr[data-id]');
+    const payload = Array.from(rows).map(row => ({
+      id: row.dataset.id,
+      low: parseFloat(row.querySelector('[name="low"]').value) || 0,
+      medium: parseFloat(row.querySelector('[name="medium"]').value) || 0,
+      high: parseFloat(row.querySelector('[name="high"]').value) || 0,
+      enabled: row.querySelector('[name="enabled"]').checked,
+      low_notify: Array.from(row.querySelectorAll('[name="low_notify"]:checked')).map(el => el.value),
+      medium_notify: Array.from(row.querySelectorAll('[name="medium_notify"]:checked')).map(el => el.value),
+      high_notify: Array.from(row.querySelectorAll('[name="high_notify"]:checked')).map(el => el.value)
+    }));
+
+    try {
+      const resp = await fetch('/system/alert_thresholds/update_all', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await resp.json();
+      if (resp.ok && data.success) {
+        if (typeof showToast === 'function') {
+          showToast('✅ Alert thresholds updated');
         }
-      } catch (err) {
-        alert('Error saving threshold');
+      } else {
+        const msg = data.error || resp.statusText;
+        if (typeof showToast === 'function') {
+          showToast(`❌ Failed to save thresholds: ${msg}`, true);
+        }
       }
-    });
+    } catch (err) {
+      if (typeof showToast === 'function') {
+        showToast('❌ Error saving thresholds', true);
+      }
+    }
   });
 });

--- a/templates/system/alert_thresholds.html
+++ b/templates/system/alert_thresholds.html
@@ -47,7 +47,7 @@
             <th>Notify (Low)</th>
             <th>Notify (Med)</th>
             <th>Notify (High)</th>
-            <th></th>
+            {# Removed per-row Save button column #}
           </tr>
         </thead>
         <tbody>
@@ -84,7 +84,6 @@
               </div>
               {% endfor %}
             </td>
-            <td><button class="btn btn-sm btn-primary save-threshold">Save</button></td>
           </tr>
           {% endfor %}
         </tbody>
@@ -92,6 +91,9 @@
     </div>
   </div>
   {% endfor %}
+  <div class="text-end mb-3">
+    <button id="saveAllThresholds" class="btn btn-primary">Save All</button>
+  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add bulk update endpoint for alert thresholds
- show "Save All" button on alert thresholds page and use toast notifications
- update JS to post all thresholds at once
- handle outdated DB schemas when updating thresholds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*