### PR TITLE
Update Hedge Labs and title bar

### DIFF
--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -21,7 +21,8 @@
       <div class="mb-3">
         <button id="linkHedgesBtn" class="btn btn-primary btn-sm me-2">Link Hedges</button>
         <button id="unlinkHedgesBtn" class="btn btn-secondary btn-sm me-2">Unlink Hedges</button>
-        <button id="testCalcsBtn" class="btn btn-info btn-sm">Test Calcs</button>
+        <button id="testCalcsBtn" class="btn btn-info btn-sm me-2">Test Calcs</button>
+        <a href="/hedge_calculator" class="btn btn-light btn-sm">Hedge Calculator</a>
       </div>
       <table class="table table-striped">
         <thead>

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -3,7 +3,6 @@
   <div class="left-buttons d-flex gap-2">
     <a class="btn btn-light nav-icon-btn" href="/" title="Home"><span>🏠</span></a>
     <a class="btn btn-light nav-icon-btn" href="{{ url_for('positions.list_positions') }}" title="Positions"><span>📊</span></a>
-    <a class="btn btn-light nav-icon-btn" href="/hedge_calculator" title="Hedge Calculator"><span>🌿</span></a>
     <a class="btn btn-light nav-icon-btn" href="/sonic_labs/hedge_labs" title="Hedge Labs"><span>🧪</span></a>
     <a class="btn btn-light nav-icon-btn" href="/alerts/status_page" title="Alert Status"><span>🚨</span></a>
     <a class="btn btn-light nav-icon-btn" href="/sonic_labs/hedge_report" title="Hedge Report"><span>🦔</span></a>


### PR DESCRIPTION
## Summary
- remove the hedge calculator button from the main title bar
- link to the hedge calculator on the Hedge Labs page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*