### PR TITLE
Fix DB corruption recovery

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -34,6 +34,20 @@ class DatabaseManager:
                     raise
         return self.conn
 
+    def recover_database(self):
+        """Recreate the database file if it's corrupt."""
+        if self.conn:
+            try:
+                self.conn.close()
+            finally:
+                self.conn = None
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+        # Fresh connection will recreate the DB file
+        self.connect()
+
     def get_cursor(self):
         return self.connect().cursor()
 

--- a/data/dl_positions.py
+++ b/data/dl_positions.py
@@ -113,6 +113,12 @@ class DLPositionManager:
             log.debug(f"Fetched {len(rows)} positions", source="DLPositionManager")
             return [dict(row) for row in rows]
         except Exception as e:
+            err_msg = str(e)
+            if "database disk image is malformed" in err_msg or "file is not a database" in err_msg:
+                log.error(f"Error fetching positions: {e}", source="DLPositionManager")
+                log.warning("Database appears corrupt. Attempting recovery...", source="DLPositionManager")
+                self.db.recover_database()
+                return []
             log.error(f"Error fetching positions: {e}", source="DLPositionManager")
             return []
 

--- a/tests/test_database_recovery.py
+++ b/tests/test_database_recovery.py
@@ -1,0 +1,38 @@
+import sqlite3
+import pytest
+import os
+
+from data.data_locker import DataLocker
+
+
+def test_recover_malformed_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
+
+    db_path = tmp_path / "test.db"
+    dl = DataLocker(str(db_path))
+
+    orig_get_cursor = dl.db.get_cursor
+
+    def failing_cursor():
+        if not hasattr(failing_cursor, "called"):
+            failing_cursor.called = True
+            raise sqlite3.DatabaseError("database disk image is malformed")
+        return orig_get_cursor()
+
+    called = {"recover": False}
+    orig_recover = dl.db.recover_database
+
+    def spy_recover():
+        called["recover"] = True
+        orig_recover()
+
+    monkeypatch.setattr(dl.db, "get_cursor", failing_cursor)
+    monkeypatch.setattr(dl.db, "recover_database", spy_recover)
+
+    positions = dl.positions.get_all_positions()
+
+    assert positions == []
+    assert called["recover"] is True
+    assert os.path.exists(db_path)
+    dl.db.close()


### PR DESCRIPTION
## Summary
- improve `DatabaseManager` with a `recover_database` helper
- automatically recover when `DLPositionManager.get_all_positions` encounters a malformed DB
- add regression test for database recovery logic

## Testing
- `pytest tests/test_database_recovery.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*