### PR TITLE
Add configurable Jupiter API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ TWILIO_AUTH_TOKEN=your_auth_token_here
 TWILIO_FLOW_SID=your_flow_sid_here
 TWILIO_FROM_PHONE=+1987654321
 TWILIO_TO_PHONE=+1234567890
+# Optional Jupiter endpoint override
+JUPITER_API_BASE=https://perps-api.jup.ag

--- a/FULL_SPEC.md
+++ b/FULL_SPEC.md
@@ -1643,7 +1643,7 @@ Internal Method
 update_jupiter_positions() → dict
 Loops through wallets
 
-Hits Jupiter API: https://perps-api.jup.ag/v1/positions
+Hits Jupiter API: `${JUPITER_API_BASE}/v1/positions`
 
 Maps and inserts valid positions
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ TWILIO_FROM_PHONE=+1987654321
 TWILIO_TO_PHONE=+1234567890
 # Optional
 TWILIO_FLOW_SID=your_flow_sid_here
+JUPITER_API_BASE=https://perps-api.jup.ag
 ```
+
+`JUPITER_API_BASE` lets you override the default Jupiter endpoint if it changes.
 
 ## Twilio Monitor
 

--- a/config/sonic_config.json
+++ b/config/sonic_config.json
@@ -25,7 +25,8 @@
     "coinmarketcap_api_enabled": "ENABLE",
     "coinpaprika_api_enabled": "ENABLE",
     "binance_api_enabled": "ENABLE",
-    "coinmarketcap_api_key": "${COINMARKETCAP_API_KEY}"
+    "coinmarketcap_api_key": "${COINMARKETCAP_API_KEY}",
+    "jupiter_api_base": "${JUPITER_API_BASE}"
   },
   "notification_config": {
     "email": {

--- a/core/constants.py
+++ b/core/constants.py
@@ -66,6 +66,11 @@ DATA_PROVIDER_ADDR = "0x69C7C30F2D9A9355Ab0F2F05aF28805F131B18C9"
 LIQUIDATION_DATA_ADDR = "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
 
 # -----------------------------
+# ☄️ Jupiter API
+# -----------------------------
+JUPITER_API_BASE = os.getenv("JUPITER_API_BASE", "https://perps-api.jup.ag")
+
+# -----------------------------
 # 🧪 Contract ABIs
 # -----------------------------
 POOL_ABI = []

--- a/positions/position_module_spec.md
+++ b/positions/position_module_spec.md
@@ -105,7 +105,7 @@ Internal Method
 update_jupiter_positions() → dict
 Loops through wallets
 
-Hits Jupiter API: https://perps-api.jup.ag/v1/positions
+Hits Jupiter API: `${JUPITER_API_BASE}/v1/positions`
 
 Maps and inserts valid positions
 

--- a/positions/position_sync_service.py
+++ b/positions/position_sync_service.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import requests
 import time
 from core.logging import log
+from core.constants import JUPITER_API_BASE
 from data.data_locker import DataLocker
 from positions.position_enrichment_service import PositionEnrichmentService
 from calc_core.calculation_core import CalculationCore
@@ -166,7 +167,7 @@ class PositionSyncService:
                     continue
 
                 try:
-                    url = f"https://perps-api.jup.ag/v1/positions?walletAddress={pub}&showTpslRequests=true"
+                    url = f"{JUPITER_API_BASE}/v1/positions?walletAddress={pub}&showTpslRequests=true"
                     res = self._request_with_retries(url)
 
                     log.debug(f"🌐 [{name}] Jupiter API status: {res.status_code}", source="JupiterAPI")


### PR DESCRIPTION
## Summary
- allow overriding Jupiter API URL via `JUPITER_API_BASE`
- build Jupiter requests with the new constant
- document the setting in README and `.env.example`
- include `jupiter_api_base` in `sonic_config.json`
- update specs referencing the URL

## Testing
- `pytest -q` *(fails: 42 errors during collection)*