### PR TITLE
Add gear link to thresholds

### DIFF
--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -83,7 +83,12 @@
   </div>
   <div class="sonic-content-panel">
       <div class="alert-bars">
-        <div class="section-title">Proximity to Alert</div>
+        <div class="section-title d-flex justify-content-between align-items-center">
+          <span>Proximity to Alert</span>
+          <a href="{{ url_for('system.list_alert_thresholds') }}" class="text-decoration-none" title="Alert Thresholds">
+            <i class="fas fa-cog"></i>
+          </a>
+        </div>
         <div id="alertBars">
       {% if alerts %}
         {% for alert in alerts %}


### PR DESCRIPTION
## Summary
- add link to Alert Thresholds in the Proximity to Alert panel on the Alert Status page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: rapidfuzz, flask, jsonschema)*