### PR TITLE
Fix alert limits page toggles

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -147,6 +147,8 @@
 {% endblock %}
 
 {% block extra_scripts %}
-<script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
-<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable theme toggle on the alert limits page

## Testing
- `pytest -q` *(fails: 42 errors during collection)*