### PR TITLE
Add toggle to thresholds and mark limits obsolete

### DIFF
--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -43,6 +43,10 @@
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel alert-limits-panel">
   <h1 class="mb-4">Alert Limits</h1>
+  <div class="alert alert-warning" role="alert">
+    ⚠️ This page is obsolete. Please use the <a href="/system/alert_thresholds" class="alert-link">Alert Thresholds</a> page instead.
+  </div>
+
   <p>This page will hold alert configuration options.</p>
 
   <form id="alertForm" method="POST" action="{{ url_for('alerts_bp.update_config') }}">

--- a/templates/system/alert_thresholds.html
+++ b/templates/system/alert_thresholds.html
@@ -100,5 +100,6 @@
 {% block extra_scripts %}
   {{ super() }}
   <script src="{{ url_for('static', filename='js/alert_thresholds.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
   <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable theme toggling on Alert Thresholds page
- mark old Alert Limits page obsolete

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*