### PR TITLE
Fix database error on Hedge Calculator

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -49,7 +49,14 @@ class DatabaseManager:
         self.connect()
 
     def get_cursor(self):
-        return self.connect().cursor()
+        """Return a database cursor, recovering the DB if corruption is detected."""
+        try:
+            return self.connect().cursor()
+        except sqlite3.DatabaseError as e:
+            if "file is not a database" in str(e) or "database disk image is malformed" in str(e):
+                self.recover_database()
+                return self.conn.cursor()
+            raise
 
     def commit(self):
         self.connect().commit()


### PR DESCRIPTION
## Summary
- make `DatabaseManager.get_cursor()` detect and recover from corrupted DB files

## Testing
- `pytest -q tests/test_database_recovery.py::test_recover_malformed_db`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*