### PR TITLE
Rename hedge calculator UI

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -437,7 +437,7 @@ def hedge_calculator_page():
         modifiers = {"hedge_modifiers": hedge_mods, "heat_modifiers": heat_mods}
 
         return render_template(
-            "hedge_calculator.html",
+            "hedge_modifiers.html",
             theme=theme_config,
             long_positions=long_positions,
             short_positions=short_positions,

--- a/templates/hedge_calculator_config.html
+++ b/templates/hedge_calculator_config.html
@@ -2,56 +2,6 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_calculator_config.css') }}">
 <!-- Rows 1-3 from hedge_calculator.html -->
 <div id="configSection">
-<div id="positionInputRow" class="row mb-4">
-  <div class="col-md-6 mb-3">
-    <div class="border rounded p-3" style="background-color: #f7f7f7;">
-      <h5 class="text-center">📈 Long Position</h5>
-      <div class="mb-2">
-        <label for="longSelect" class="form-label"><strong>Select Long Position</strong></label>
-        <select id="longSelect" class="form-select" onchange="loadLongPosition()">
-          <option value="" disabled {% if not default_long_id %}selected{% endif %}>-- Choose a Position --</option>
-          {% for pos in long_positions %}
-          <option value="{{ pos.id }}" {% if pos.id == default_long_id %}selected{% endif %}>{{ pos.asset_type }} - Entry: ${{ pos.entry_price }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="mb-2">
-        <label for="longEntry" class="form-label"><strong>Entry Price ($):</strong></label>
-        <input type="number" id="longEntry" class="form-control" step="any" readonly />
-      </div>
-      <div class="mb-2">
-        <label for="longSize" class="form-label"><strong>Position Size (USD):</strong></label>
-        <input type="number" id="longSize" class="form-control" step="any" />
-      </div>
-      <input type="hidden" id="longCollateral" />
-      <input type="hidden" id="longLiqPrice" />
-    </div>
-  </div>
-  <div class="col-md-6 mb-3">
-    <div class="border rounded p-3" style="background-color: #f7f7f7;">
-      <h5 class="text-center">📉 Short Position</h5>
-      <div class="mb-2">
-        <label for="shortSelect" class="form-label"><strong>Select Short Position</strong></label>
-        <select id="shortSelect" class="form-select" onchange="loadShortPosition()">
-          <option value="" disabled {% if not default_short_id %}selected{% endif %}>-- Choose a Position --</option>
-          {% for pos in short_positions %}
-          <option value="{{ pos.id }}" {% if pos.id == default_short_id %}selected{% endif %}>{{ pos.asset_type }} - Entry: ${{ pos.entry_price }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="mb-2">
-        <label for="shortEntry" class="form-label"><strong>Entry Price ($):</strong></label>
-        <input type="number" id="shortEntry" class="form-control" step="any" readonly />
-      </div>
-      <div class="mb-2">
-        <label for="shortSize" class="form-label"><strong>Position Size (USD):</strong></label>
-        <input type="number" id="shortSize" class="form-control" step="any" />
-      </div>
-      <input type="hidden" id="shortCollateral" />
-      <input type="hidden" id="shortLiqPrice" />
-    </div>
-  </div>
-</div>
 
 <!-- Row 2: Modifier Boxes -->
 <div id="modifierRow" class="row mb-4">

--- a/templates/hedge_calculator_results.html
+++ b/templates/hedge_calculator_results.html
@@ -1,20 +1,7 @@
 <!-- Hedge Calculator Results Section -->
 <!-- Rows 4-6 from hedge_calculator.html -->
 <div id="projectedOutputRow" class="row mb-4">
-  <div class="col-md-6 slider-box mb-3">
-    <label for="priceSlider" class="form-label"><strong>Simulated Price</strong></label>
-    <input type="range" class="form-range" id="priceSlider" step="0.01">
-    <div class="d-flex justify-content-between">
-      <small id="tickLeft">$0</small>
-      <small id="tickRight">$0</small>
-    </div>
-    <div class="position-relative" style="height:20px;">
-      <span id="entryMarkerLong" class="position-absolute text-success small"></span>
-      <span id="entryMarkerShort" class="position-absolute text-danger small"></span>
-      <span id="currentMarker" class="position-absolute text-primary small"></span>
-    </div>
-    <button class="btn btn-sm btn-secondary mt-2" onclick="resetPriceToCurrent()">Reset Price</button>
-  </div>
+  <!-- Price slider removed -->
   <div class="col-md-6 slider-box mb-3">
     <label for="leverageSlider" class="form-label"><strong>Projected Leverage</strong></label>
     <input type="range" class="form-range" id="leverageSlider" min="1" max="20" step="0.1">

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -22,7 +22,7 @@
         <button id="linkHedgesBtn" class="btn btn-primary btn-sm me-2">Link Hedges</button>
         <button id="unlinkHedgesBtn" class="btn btn-secondary btn-sm me-2">Unlink Hedges</button>
         <button id="testCalcsBtn" class="btn btn-info btn-sm me-2">Test Calcs</button>
-        <a href="/hedge_calculator" class="btn btn-light btn-sm">Hedge Calculator</a>
+        <a href="/hedge_calculator" class="btn btn-light btn-sm">Hedge Modifiers</a>
       </div>
       <table class="table table-striped">
         <thead>

--- a/templates/hedge_modifiers.html
+++ b/templates/hedge_modifiers.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Hedge Calculator{% endblock %}
+{% block title %}Hedge Modifiers{% endblock %}
 
 {% block extra_styles %}
 {{ super() }}
@@ -24,10 +24,10 @@
     </div>
   </div>
 
-  <!-- Main Card for Hedge Calculator -->
+  <!-- Main Card for Hedge Modifiers -->
   <div class="card shadow mb-4">
     <div class="card-header position-relative" style="background-color: var(--card-title-color);">
-      <h4 class="mb-0 text-center" style="color: var(--text-color);">🦔 Hedge Calculator</h4>
+      <h4 class="mb-0 text-center" style="color: var(--text-color);">🦔 Hedge Modifiers</h4>
       <button id="toggleConfig" class="btn btn-sm btn-outline-secondary position-absolute" style="top: 10px; right: 50px;" title="Hide Config">
         <i class="fa-solid fa-eye-slash"></i>
       </button>

--- a/tests/test_hedge_calculator_page.py
+++ b/tests/test_hedge_calculator_page.py
@@ -38,9 +38,9 @@ def client(monkeypatch):
     with app.test_client() as client:
         yield client
 
-def test_hedge_calculator_page_contains_sliders(client):
+def test_hedge_modifiers_page_contains_inputs(client):
     response = client.get("/sonic_labs/hedge_calculator")
     assert response.status_code == 200
     html = response.data.decode()
-    assert "priceSlider" in html
-    assert "leverageSlider" in html
+    assert "feePercentage" in html
+    assert "distanceWeightInput" in html

--- a/tests/test_profit_badge_routes.py
+++ b/tests/test_profit_badge_routes.py
@@ -17,7 +17,7 @@ def client(monkeypatch):
     # Simplify heavy view logic
     app.view_functions["alerts.alert_status_page"] = lambda: render_template("alert_status.html", alerts=[])
     app.view_functions["system.hedge_calculator_page"] = lambda: render_template(
-        "hedge_calculator.html",
+        "hedge_modifiers.html",
         theme={},
         long_positions=[],
         short_positions=[],


### PR DESCRIPTION
## Summary
- rename hedge calculator template to `hedge_modifiers.html`
- adjust header to "Hedge Modifiers"
- remove position selection and price slider sections
- update route and links to new template name
- fix tests for renamed template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError rapidfuzz, flask, jsonschema)*