### PR TITLE
Honor alert config enable flags

### DIFF
--- a/alert_core/alert_core.py
+++ b/alert_core/alert_core.py
@@ -12,11 +12,11 @@ class AlertCore:
     def __init__(self, data_locker, config_loader):
         self.data_locker = data_locker
         self.config_loader = config_loader
-        self.repo = AlertStore(data_locker)
+        self.repo = AlertStore(data_locker, config_loader)
         self.enricher = AlertEnrichmentService(data_locker)
         threshold_service = ThresholdService(data_locker.db)
         self.evaluator = AlertEvaluationService(threshold_service)
-        self.alert_store = AlertStore(data_locker)
+        self.alert_store = AlertStore(data_locker, config_loader)
         self.evaluator.inject_repo(self.repo)  # ⚡️ enable DB updates
 
     async def create_alert(self, alert_dict: dict) -> bool:


### PR DESCRIPTION
## Summary
- allow passing config loader to AlertStore
- skip disabled metrics when generating position or portfolio alerts
- wire AlertCore to pass the loader to AlertStore

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*