### PR TITLE
Update Hedge Labs page

### DIFF
--- a/static/js/hedge_labs.js
+++ b/static/js/hedge_labs.js
@@ -7,7 +7,16 @@ function loadHedges() {
         tbody.innerHTML = '';
         (data.hedges || []).forEach(h => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${h.id}</td><td>${h.positions.join(', ')}</td><td>${h.total_heat_index}</td>`;
+          const assetImg = `/static/images/${h.asset_image}`;
+          const walletImg = `/static/images/${h.wallet_image}`;
+          tr.innerHTML = `
+            <td>
+              <img class="asset-icon me-1" src="${assetImg}" alt="asset">
+              <span class="mx-1">⛓️</span>
+              <img class="wallet-icon ms-1" src="${walletImg}" alt="wallet">
+            </td>
+            <td>${h.positions.join(', ')}</td>
+            <td>${h.total_heat_index}</td>`;
           tbody.appendChild(tr);
         });
       }
@@ -111,14 +120,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   const linkBtn = document.getElementById('linkHedgesBtn');
   const unlinkBtn = document.getElementById('unlinkHedgesBtn');
-  const testBtn = document.getElementById('testCalcsBtn');
   if (linkBtn) linkBtn.addEventListener('click', () => postAction('/sonic_labs/api/link_hedges'));
   if (unlinkBtn) unlinkBtn.addEventListener('click', () => postAction('/sonic_labs/api/unlink_hedges'));
-  if (testBtn) testBtn.addEventListener('click', () => {
-    fetch('/sonic_labs/api/test_calcs').then(resp => resp.json()).then(res => {
-      console.log('Calc Totals', res);
-    });
-  });
 
   const select = document.getElementById('hedgeSelect');
   const slider = document.getElementById('priceSlider');

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -19,15 +19,20 @@
     </div>
     <div class="card-body">
       <div class="mb-3">
-        <button id="linkHedgesBtn" class="btn btn-primary btn-sm me-2">Link Hedges</button>
-        <button id="unlinkHedgesBtn" class="btn btn-secondary btn-sm me-2">Unlink Hedges</button>
-        <button id="testCalcsBtn" class="btn btn-info btn-sm me-2">Test Calcs</button>
-        <a href="/hedge_calculator" class="btn btn-light btn-sm">Hedge Modifiers</a>
+        <button id="linkHedgesBtn" class="btn btn-outline-primary btn-sm me-2">
+          <i class="fas fa-link me-1"></i>Link Hedges
+        </button>
+        <button id="unlinkHedgesBtn" class="btn btn-outline-secondary btn-sm me-2">
+          <i class="fas fa-unlink me-1"></i>Unlink Hedges
+        </button>
+        <a href="/hedge_calculator" class="btn btn-outline-light btn-sm">
+          <i class="fas fa-sliders-h me-1"></i>Hedge Modifiers
+        </a>
       </div>
       <table class="table table-striped">
         <thead>
           <tr>
-            <th>ID</th>
+            <th>Hedged Position</th>
             <th>Positions</th>
             <th>Total Heat</th>
           </tr>
@@ -35,7 +40,11 @@
         <tbody id="hedgeTableBody">
           {% for h in hedges %}
           <tr>
-            <td>{{ h.id }}</td>
+            <td>
+              <img class="asset-icon me-1" src="{{ url_for('static', filename='images/' + h.asset_image) }}" alt="asset">
+              <span class="mx-1">⛓️</span>
+              <img class="wallet-icon ms-1" src="{{ url_for('static', filename='images/' + h.wallet_image) }}" alt="wallet">
+            </td>
             <td>{{ h.positions|join(', ') }}</td>
             <td>{{ h.total_heat_index }}</td>
           </tr>


### PR DESCRIPTION
## Summary
- enhance Hedge Labs blueprint to send asset & wallet icons
- simplify button controls and styling
- display icons instead of ID column
- remove `testCalcs` handling in JavaScript

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*