### PR TITLE
Fix dashboard wallpaper to use theme variable

### DIFF
--- a/static/css/dashboard_parallax.css
+++ b/static/css/dashboard_parallax.css
@@ -1,6 +1,7 @@
 /* Parallax effect for Sonic Dashboard page */
 body.dashboard-parallax {
-  background-image: url('/static/images/Wally.png');
+  /* Use theme-provided wallpaper for dashboard background */
+  background-image: var(--body-bg-image);
   background-attachment: fixed;
   background-size: cover;
   background-position: center;


### PR DESCRIPTION
## Summary
- use `var(--body-bg-image)` in dashboard parallax css so the dashboard wallpaper honors the selected theme

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*