### PR TITLE
Update Hedge Labs UI

### DIFF
--- a/static/js/hedge_labs.js
+++ b/static/js/hedge_labs.js
@@ -34,6 +34,23 @@ function postAction(url) {
 let currentHedgeId = null;
 let hedgePositions = [];
 
+function setPriceDisplay(price) {
+  const wrapper = document.getElementById('priceValue');
+  if (!wrapper) return;
+  const img = document.getElementById('priceAssetIcon');
+  const text = document.getElementById('priceText');
+  if (img) {
+    const hedge = (window.initialHedges || []).find(h => String(h.id) === String(currentHedgeId));
+    if (hedge && hedge.asset_image) {
+      img.src = `/static/images/${hedge.asset_image}`;
+      img.classList.remove('d-none');
+    } else {
+      img.classList.add('d-none');
+    }
+  }
+  if (text) text.textContent = 'Price: $' + price.toFixed(2);
+}
+
 function loadHedgePositions(id) {
   fetch(`/sonic_labs/api/hedge_positions?hedge_id=${id}`)
     .then(resp => resp.json())
@@ -68,14 +85,14 @@ function initSlider() {
   slider.max = max;
   const clamped = Math.min(Math.max(current, min), max);
   slider.value = clamped;
-  document.getElementById('priceValue').textContent = 'Price: $' + current.toFixed(2);
+  setPriceDisplay(current);
 }
 
 function updateEvaluation() {
   const slider = document.getElementById('priceSlider');
   if (!slider || !currentHedgeId) return;
   const price = parseFloat(slider.value);
-  document.getElementById('priceValue').textContent = 'Price: $' + price.toFixed(2);
+  setPriceDisplay(price);
   fetch(`/sonic_labs/api/evaluate_hedge?hedge_id=${currentHedgeId}&price=${price}`)
     .then(resp => resp.json())
     .then(data => updateTable(data));

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -56,7 +56,7 @@
 
   <div class="card mt-4">
     <div class="card-header">
-      <strong><span class="me-1">🧮</span>Calculator</strong>
+      <strong><span class="me-1">🖩</span>Calculator</strong>
     </div>
     <div class="card-body">
       <div class="row mb-3">
@@ -72,7 +72,10 @@
         <div class="col-md-8">
           <label for="priceSlider" class="form-label"><strong>Simulated Price</strong></label>
           <input type="range" id="priceSlider" class="form-range" step="0.01" disabled>
-          <div id="priceValue" class="mt-2">Price: 0</div>
+          <div id="priceValue" class="mt-2 d-flex align-items-center">
+            <img id="priceAssetIcon" class="asset-icon me-1 d-none" alt="asset">
+            <strong id="priceText">Price: 0</strong>
+          </div>
         </div>
       </div>
       <table class="table table-sm" id="evalTable">


### PR DESCRIPTION
## Summary
- adjust Hedge Labs calculator icon to a calculator emoji
- move asset icon next to simulated price
- show price in bold text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*