### PR TITLE
Fix Hedge Labs layout

### DIFF
--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -12,90 +12,85 @@
 {% include "title_bar.html" %}
 <div class="container-fluid p-3">
   <h3 class="mb-3">🧪 Hedge Labs</h3>
-
-  <div class="card mb-4">
-    <div class="card-header">
-      <strong><span class="me-1">🦔</span>Hedges</strong>
-    </div>
-    <div class="card-body">
-      <div class="mb-3">
-        <button id="linkHedgesBtn" class="btn btn-outline-primary btn-sm me-2">
-          <i class="fas fa-link me-1"></i>Link Hedges
-        </button>
-        <button id="unlinkHedgesBtn" class="btn btn-outline-secondary btn-sm me-2">
-          <i class="fas fa-unlink me-1"></i>Unlink Hedges
-        </button>
-        <a href="/hedge_calculator" class="btn btn-outline-light btn-sm">
-          <i class="fas fa-sliders-h me-1"></i>Hedge Modifiers
-        </a>
-      </div>
-      <table class="table table-striped">
-        <thead>
-          <tr>
-            <th>Hedged Position</th>
-            <th>Positions</th>
-            <th>Total Heat</th>
-          </tr>
-        </thead>
-        <tbody id="hedgeTableBody">
-          {% for h in hedges %}
-          <tr>
-            <td>
-              <img class="asset-icon me-1" src="{{ url_for('static', filename='images/' + h.asset_image) }}" alt="asset">
-              <span class="mx-1">⛓️</span>
-              <img class="wallet-icon ms-1" src="{{ url_for('static', filename='images/' + h.wallet_image) }}" alt="wallet">
-            </td>
-            <td>{{ h.positions|join(', ') }}</td>
-            <td>{{ h.total_heat_index }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </div>
-
-  <div class="card mt-4">
-    <div class="card-header">
-      <strong><span class="me-1">🖩</span>Calculator</strong>
-    </div>
-    <div class="card-body">
-      <div class="row mb-3">
-        <div class="col-md-4">
-          <label for="hedgeSelect" class="form-label"><strong>Select Hedge</strong></label>
-          <select id="hedgeSelect" class="form-select">
-            <option value="" disabled selected>-- Choose Hedge --</option>
-            {% for h in hedges %}
-            <option value="{{ h.id }}">{{ h.id }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="col-md-8">
-          <label for="priceSlider" class="form-label"><strong>Simulated Price</strong></label>
-          <input type="range" id="priceSlider" class="form-range" step="0.01" disabled>
-          <div id="priceValue" class="mt-2 d-flex align-items-center">
-            <img id="priceAssetIcon" class="asset-icon me-1 d-none" alt="asset">
-            <strong id="priceText">Price: 0</strong>
-          </div>
-        </div>
-      </div>
-      <table class="table table-sm" id="evalTable">
-        <thead>
-          <tr>
-            <th><i class="fas fa-map-marker-alt me-1"></i>Position</th>
-            <th><i class="fas fa-dollar-sign me-1"></i>Value</th>
-            <th><i class="fas fa-route me-1"></i>Travel %</th>
-            <th><i class="fas fa-ruler me-1"></i>Liq&nbsp;Dist</th>
-            <th><i class="fas fa-fire me-1"></i>Heat</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-    </div>
-  </div>
-  <script>
-    window.initialHedges = {{ hedges | tojson }};
-  </script>
 </div>
+
+<div class="sonic-section-container sonic-section-middle mt-3">
+  <div class="sonic-content-panel">
+    <div class="section-title icon-inline"><span>🦔</span><span>Hedges</span></div>
+    <div class="mb-3">
+      <button id="linkHedgesBtn" class="btn btn-outline-primary btn-sm me-2">
+        <i class="fas fa-link me-1"></i>Link Hedges
+      </button>
+      <button id="unlinkHedgesBtn" class="btn btn-outline-secondary btn-sm me-2">
+        <i class="fas fa-unlink me-1"></i>Unlink Hedges
+      </button>
+      <a href="/hedge_calculator" class="btn btn-outline-light btn-sm">
+        <i class="fas fa-sliders-h me-1"></i>Hedge Modifiers
+      </a>
+    </div>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Hedged Position</th>
+          <th>Positions</th>
+          <th>Total Heat</th>
+        </tr>
+      </thead>
+      <tbody id="hedgeTableBody">
+        {% for h in hedges %}
+        <tr>
+          <td>
+            <img class="asset-icon me-1" src="{{ url_for('static', filename='images/' + h.asset_image) }}" alt="asset">
+            <span class="mx-1">⛓️</span>
+            <img class="wallet-icon ms-1" src="{{ url_for('static', filename='images/' + h.wallet_image) }}" alt="wallet">
+          </td>
+          <td>{{ h.positions|join(', ') }}</td>
+          <td>{{ h.total_heat_index }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="sonic-content-panel">
+    <div class="section-title icon-inline"><span>🖩</span><span>Calculator</span></div>
+    <div class="row mb-3">
+      <div class="col-md-4">
+        <label for="hedgeSelect" class="form-label"><strong>Select Hedge</strong></label>
+        <select id="hedgeSelect" class="form-select">
+          <option value="" disabled selected>-- Choose Hedge --</option>
+          {% for h in hedges %}
+          <option value="{{ h.id }}">{{ h.id }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-md-8">
+        <label for="priceSlider" class="form-label"><strong>Simulated Price</strong></label>
+        <input type="range" id="priceSlider" class="form-range" step="0.01" disabled>
+        <div id="priceValue" class="mt-2 d-flex align-items-center">
+          <img id="priceAssetIcon" class="asset-icon me-1 d-none" alt="asset">
+          <strong id="priceText">Price: 0</strong>
+        </div>
+      </div>
+    </div>
+    <table class="table table-sm" id="evalTable">
+      <thead>
+        <tr>
+          <th><i class="fas fa-map-marker-alt me-1"></i>Position</th>
+          <th><i class="fas fa-dollar-sign me-1"></i>Value</th>
+          <th><i class="fas fa-route me-1"></i>Travel %</th>
+          <th><i class="fas fa-ruler me-1"></i>Liq&nbsp;Dist</th>
+          <th><i class="fas fa-fire me-1"></i>Heat</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+  window.initialHedges = {{ hedges | tojson }};
+</script>
 {% endblock %}
 
 {% block extra_scripts %}
@@ -104,3 +99,4 @@
 <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
 <script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- wrap Hedge Labs panels in standard layout container so layout mode toggle works

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: rapidfuzz)*