### PR TITLE
Implement themed page titles

### DIFF
--- a/static/css/sonic_titles.css
+++ b/static/css/sonic_titles.css
@@ -1,0 +1,30 @@
+.sonic-title-wrapper {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.sonic-title-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 1.4rem;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  border-radius: 50px;
+  box-shadow: inset 0 0 5px #ffa726;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.sonic-title-pill.default {
+  background: #cce5ff;
+  color: #232946;
+}
+
+.sonic-title-pill.dashboard {
+  background: #7c3aed;
+  color: #fff;
+}

--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
   <style>
     .save-spinner {
       display: none;

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_middle.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/liquidation_bars.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/alert_status.css') }}">

--- a/templates/db_viewer.html
+++ b/templates/db_viewer.html
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
   <style>
     body {
       background-image: url('{{ url_for('static', filename='images/database_wall.jpg') }}');

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -6,6 +6,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/hedge_modifiers.html
+++ b/templates/hedge_modifiers.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_calculator.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_report.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/positions/portfolio.html
+++ b/templates/positions/portfolio.html
@@ -6,6 +6,7 @@
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/positions/positions.html
+++ b/templates/positions/positions.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/liquidation_bars.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_middle.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_parallax.css') }}">
@@ -13,7 +14,7 @@
 {% endblock %}
 
 {% block content %}
-  {% include "title_bar.html" %}
+  {% include "title_bar.html" with title_text='Dashboard', title_theme='dashboard' %}
   {% include "dash_top.html" %}
   {% include "dash_middle.html" %}
   {% include "dash_bottom.html" %}

--- a/templates/sonic_titles.html
+++ b/templates/sonic_titles.html
@@ -1,0 +1,5 @@
+<div class="sonic-title-wrapper">
+  <div class="sonic-title-pill {{ title_theme|default('default') }}">
+    {{ title_text|default('Sonic') }}
+  </div>
+</div>

--- a/templates/system/alert_thresholds.html
+++ b/templates/system/alert_thresholds.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/system/xcom_config.html
+++ b/templates/system/xcom_config.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -49,6 +49,7 @@
     </div>
   </div>
   </nav>
+  {% include "sonic_titles.html" %}
   <script src="{{ url_for('static', filename='js/refresh_timer.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
 

--- a/templates/wallets/wallet_list.html
+++ b/templates/wallets/wallet_list.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- add `sonic_titles.html` and stylesheet for pill-shaped page titles
- include the new title component from the title bar
- allow Dashboard page to specify title text and theme
- load new stylesheet on pages that use the title bar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*