### PR TITLE
Implement themed page titles

### DIFF
--- a/static/css/sonic_titles.css
+++ b/static/css/sonic_titles.css
@@ -1,0 +1,30 @@
+.sonic-title-wrapper {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.sonic-title-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 1.4rem;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  border-radius: 50px;
+  box-shadow: inset 0 0 5px #ffa726;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.sonic-title-pill.default {
+  background: #cce5ff;
+  color: #232946;
+}
+
+.sonic-title-pill.dashboard {
+  background: #7c3aed;
+  color: #fff;
+}

--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
   <style>
     .save-spinner {
       display: none;
@@ -39,10 +40,10 @@
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Alert Limits' %}
 {% include "title_bar.html" %}
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel alert-limits-panel">
-  <h1 class="mb-4">Alert Limits</h1>
   <div class="alert alert-warning" role="alert">
     ⚠️ This page is obsolete. Please use the <a href="/system/alert_thresholds" class="alert-link">Alert Thresholds</a> page instead.
   </div>

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -7,12 +7,14 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_middle.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/liquidation_bars.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/alert_status.css') }}">
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Alert Status' %}
 {% include "title_bar.html" %}
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel">

--- a/templates/db_viewer.html
+++ b/templates/db_viewer.html
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
   <style>
     body {
       background-image: url('{{ url_for('static', filename='images/database_wall.jpg') }}');
@@ -22,9 +23,9 @@
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Database Viewer' %}
 {% include "title_bar.html" %}
 <div class="container py-4 db-viewer-container">
-  <h2 class="mb-3">Database Viewer</h2>
   <div class="mb-3">
     <label for="tableSelect" class="form-label">Select Table:</label>
     <select id="tableSelect" class="form-select" onchange="showTable(this.value)">

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -6,13 +6,12 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Hedge Labs' %}
 {% include "title_bar.html" %}
-<div class="container-fluid p-3">
-  <h3 class="mb-3">🧪 Hedge Labs</h3>
-</div>
 
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel">

--- a/templates/hedge_modifiers.html
+++ b/templates/hedge_modifiers.html
@@ -7,9 +7,11 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_calculator.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Hedge Modifiers' %}
 {% include "title_bar.html" %}
 <div class="container-fluid">
   <!-- Display Mode Radio Buttons -->

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -9,18 +9,17 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_report.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Hedge Report' %}
 {% include "title_bar.html" %}
 
 
 {% set hd = heat_data|default({}) %}
 
-<!-- Page Title -->
-<h2 class="text-dark mb-4 icon-inline">
-  <span>🦔</span><span>Hedge Report</span>
-</h2>
+<!-- Page Title Removed -->
 
 <div class="container-fluid px-4">
   <div class="row">

--- a/templates/positions/portfolio.html
+++ b/templates/positions/portfolio.html
@@ -6,12 +6,13 @@
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Portfolio History' %}
 {% include "title_bar.html" %}
 <div class="container pt-4">
-  <h1 class="mb-4">📈 Portfolio History</h1>
   {% if percent_change is not none %}
     <p class="lead">Overall Change: {{ percent_change|round(2) }}%</p>
   {% endif %}

--- a/templates/positions/positions.html
+++ b/templates/positions/positions.html
@@ -7,9 +7,11 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Positions' %}
 {% include "title_bar.html" %}
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel">

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/liquidation_bars.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_middle.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_parallax.css') }}">
@@ -13,6 +14,8 @@
 {% endblock %}
 
 {% block content %}
+  {% set title_text = 'Dashboard' %}
+  {% set title_theme = 'dashboard' %}
   {% include "title_bar.html" %}
   {% include "dash_top.html" %}
   {% include "dash_middle.html" %}

--- a/templates/sonic_titles.html
+++ b/templates/sonic_titles.html
@@ -1,0 +1,5 @@
+<div class="sonic-title-wrapper">
+  <div class="sonic-title-pill {{ title_theme|default('default') }}">
+    {{ title_text|default('Sonic') }}
+  </div>
+</div>

--- a/templates/system/alert_thresholds.html
+++ b/templates/system/alert_thresholds.html
@@ -7,12 +7,14 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Alert Thresholds' %}
 {% include "title_bar.html" %}
 <div class="container-fluid pt-4">
-  <h2 class="mb-4"><i class="fas fa-ruler me-2"></i>Alert Thresholds</h2>
+  <!-- Title moved to bar -->
   {% set type_icons = {
     'pricethreshold': '💵',
     'deltachange': '📊',

--- a/templates/system/xcom_config.html
+++ b/templates/system/xcom_config.html
@@ -7,12 +7,14 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'XCom Settings' %}
 {% include "title_bar.html" %}
 <div class="container-fluid pt-4">
-  <h2 class="mb-4"><i class="fas fa-plug text-primary me-2"></i>XCom Settings</h2>
+  <!-- Title moved to bar -->
 
   <div class="row g-4">
 

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -49,6 +49,7 @@
     </div>
   </div>
   </nav>
+  {% include "sonic_titles.html" %}
   <script src="{{ url_for('static', filename='js/refresh_timer.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
 

--- a/templates/wallets/wallet_list.html
+++ b/templates/wallets/wallet_list.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- add `sonic_titles.html` and stylesheet for pill-shaped page titles
- include the new title component from the title bar
- allow Dashboard page to specify title text and theme
- load new stylesheet on pages that use the title bar
- fix dashboard syntax and centralize page titles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*