### PR TITLE
Remove 'Hedge Labs' page heading

### DIFF
--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -11,9 +11,6 @@
 
 {% block content %}
 {% include "title_bar.html" %}
-<div class="container-fluid p-3">
-  <h3 class="mb-3">🧪 Hedge Labs</h3>
-</div>
 
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel">


### PR DESCRIPTION
## Summary
- remove heading '🧪 Hedge Labs' from the Hedge Labs page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*