### PR TITLE
Fix totals to ignore inactive positions

### DIFF
--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -149,7 +149,7 @@ def api_graph_data():
 def api_size_composition():
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_all_positions() or []
+        positions = core.get_active_positions() or []
 
         long_total = sum(float(p.get("size", 0)) for p in positions if str(p.get("position_type", "")).upper() == "LONG")
         short_total = sum(float(p.get("size", 0)) for p in positions if str(p.get("position_type", "")).upper() == "SHORT")
@@ -175,7 +175,7 @@ def api_size_composition():
 def api_collateral_composition():
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_all_positions() or []
+        positions = core.get_active_positions() or []
 
         long_total = sum(float(p.get("collateral", 0)) for p in positions if str(p.get("position_type", "")).upper() == "LONG")
         short_total = sum(float(p.get("collateral", 0)) for p in positions if str(p.get("position_type", "")).upper() == "SHORT")

--- a/app/positions_bp.py
+++ b/app/positions_bp.py
@@ -40,7 +40,7 @@ def _convert_iso_to_pst(iso_str):
 def list_positions():
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_all_positions()
+        positions = core.get_active_positions()
 
         config_data = load_config(str(ALERT_LIMITS_PATH)) or {}
         alert_dict = config_data.get("alert_ranges", {})
@@ -86,7 +86,7 @@ def list_positions():
 def positions_table():
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_all_positions()
+        positions = core.get_active_positions()
         totals = CalcServices().calculate_totals(positions)
         return render_template("positions_table.html", positions=positions, totals=totals)
     except Exception as e:
@@ -167,7 +167,7 @@ def update_jupiter():
 def positions_data_api():
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_all_positions()
+        positions = core.get_active_positions()
         mini_prices = []
         for asset in ["BTC", "ETH", "SOL"]:
             row = current_app.data_locker.get_latest_price(asset)

--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -399,7 +399,7 @@ def hedge_calculator_page():
     """Render the hedge calculator page."""
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_all_positions() or []
+        positions = core.get_active_positions() or []
 
         long_positions = [
             p for p in positions if str(p.get("position_type", "")).upper() == "LONG"
@@ -454,7 +454,7 @@ def hedge_report_page():
     """Render the hedge report page with aggregated long/short data."""
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_all_positions() or []
+        positions = core.get_active_positions() or []
 
         def build(group_positions, asset_name):
             from calc_core.calc_services import CalcServices

--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -208,7 +208,7 @@ def get_profit_badge_value(data_locker, system_core=None):
             return None
 
         low_limit = profit_threshold.low
-        positions = PositionCore(data_locker).get_all_positions() or []
+        positions = PositionCore(data_locker).get_active_positions() or []
         profits = [float(p.get("pnl_after_fees_usd") or 0.0) for p in positions]
         above = [p for p in profits if p >= low_limit]
         if above:
@@ -221,7 +221,7 @@ def get_dashboard_context(data_locker, system_core=None):
 
     log.info("📊 Assembling dashboard context", source="DashboardContext")
     core = CalculationCore(data_locker)
-    positions = PositionCore(data_locker).get_all_positions() or []
+    positions = PositionCore(data_locker).get_active_positions() or []
     positions = core.aggregate_positions_and_update(positions, DB_PATH)
     totals = core.calc_services.calculate_totals(positions)
 

--- a/positions/position_core.py
+++ b/positions/position_core.py
@@ -34,9 +34,9 @@ class PositionCore:
 
     def record_snapshot(self):
         try:
-            raw = self.store.get_all()
+            raw = self.store.get_active_positions()
             totals = CalcServices().calculate_totals(raw)
-            self.dl.portfolio.record_snapshot(totals)  # ✅ HERE
+            self.dl.portfolio.record_snapshot(totals)
             log.success("📸 Position snapshot recorded", source="PositionCore")
         except Exception as e:
             log.error(f"❌ Snapshot recording failed: {e}", source="PositionCore")

--- a/positions/position_core_service.py
+++ b/positions/position_core_service.py
@@ -58,7 +58,7 @@ class PositionCoreService:
 
     def record_positions_snapshot(self):
         try:
-            positions = self.dl.read_positions()
+            positions = self.dl.positions.get_active_positions()
             calc = CalculationCore(self.dl)
             totals = calc.calculate_totals(positions)
             self.dl.portfolio.record_snapshot(totals)

--- a/positions/position_sync_service.py
+++ b/positions/position_sync_service.py
@@ -81,7 +81,8 @@ class PositionSyncService:
             })
 
             calc_core = CalculationCore(self.dl)
-            totals = calc_core.calculate_totals(positions)
+            active_positions = self.dl.positions.get_active_positions()
+            totals = calc_core.calculate_totals(active_positions)
             self.dl.portfolio.record_snapshot(totals)
 
             # Step 4: HTML Report

--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -214,7 +214,7 @@ def api_test_calcs():
         from calc_core.calculation_core import CalculationCore
 
         dl = current_app.data_locker
-        positions = dl.positions.get_all_positions() or []
+        positions = dl.positions.get_active_positions() or []
         core = CalculationCore(dl)
         totals = core.calculate_totals(positions)
         return jsonify({"totals": totals})

--- a/tests/test_active_totals.py
+++ b/tests/test_active_totals.py
@@ -1,0 +1,44 @@
+import pytest
+from positions.position_core import PositionCore
+from data.data_locker import DataLocker
+from calc_core.calc_services import CalcServices
+
+
+def test_totals_exclude_inactive(tmp_path):
+    db_path = tmp_path / "test.db"
+    dl = DataLocker(str(db_path))
+    core = PositionCore(dl)
+
+    active_pos = {
+        "id": "pos1",
+        "asset_type": "BTC",
+        "position_type": "LONG",
+        "size": 1.0,
+        "value": 100.0,
+        "collateral": 50.0,
+        "leverage": 2.0,
+        "travel_percent": 5.0,
+        "status": "ACTIVE",
+    }
+    inactive_pos = {
+        "id": "pos2",
+        "asset_type": "ETH",
+        "position_type": "SHORT",
+        "size": 2.0,
+        "value": 200.0,
+        "collateral": 100.0,
+        "leverage": 3.0,
+        "travel_percent": 10.0,
+        "status": "CLOSED",
+    }
+
+    core.create_position(active_pos)
+    core.create_position(inactive_pos)
+
+    core.record_snapshot()
+    snap = dl.portfolio.get_latest_snapshot()
+
+    assert snap["total_value"] == active_pos["value"]
+    assert snap["total_size"] == active_pos["size"]
+    assert snap["total_collateral"] == active_pos["collateral"]
+


### PR DESCRIPTION
## Summary
- only count active positions when recording a snapshot
- base dashboard totals on active positions
- show active positions on dashboard and API routes
- sync service and core service snapshots use active positions
- adjust Sonic Labs test calcs for active positions
- add regression test for inactive position totals

## Testing
- `pytest -q` *(fails: 43 errors during collection)*