### PR TITLE
Fix dashboard template for Jinja2 compatibility

### DIFF
--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -17,7 +17,10 @@
 
   {% set title_text = 'Dashboard' %}
   {% set title_theme = 'dashboard' %}
-  {% include "title_bar.html" with title_text='Dashboard', title_theme='dashboard' %}
+  {# Older Jinja versions do not support passing variables with the
+     `include` statement. We set the variables above and rely on the
+     default context propagation. #}
+  {% include "title_bar.html" %}
   {% include "dash_top.html" %}
   {% include "dash_middle.html" %}
   {% include "dash_bottom.html" %}


### PR DESCRIPTION
## Summary
- fix Jinja2 syntax to avoid dashboard crash

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*