### PR TITLE
Remove text from alert asset column

### DIFF
--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -56,7 +56,6 @@
               <td class="left">
                 <span class="icon-inline">
                   <img class="asset-icon" src="{{ url_for('static', filename='images/' + alert.asset_image) }}" alt="{{ alert.asset }}">
-                  {{ alert.asset or 'N/A' }}
                 </span>
                 <span style="display:none">{{ alert.asset or 'N/A' }}</span>
               </td>


### PR DESCRIPTION
## Summary
- adjust alert status table to show only asset icon

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*