### PR TITLE
UI tweaks: timer placement and title alignment

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -163,6 +163,12 @@
   transition: transform 0.2s ease;
 }
 
+.settings-btn {
+  font-size: 1.6rem;
+  min-width: 32px;
+  min-height: 32px;
+}
+
 /* Navigation buttons on the left */
 .nav-btn {
   font-size: 1.2rem;

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -9,15 +9,8 @@
     <a class="btn nav-btn" href="/system/wallets" title="Wallet Manager"><span>💼</span></a>
   </div>
   <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
-    <div id="refreshDial" class="refresh-dial" title="UI auto-refresh">
-      <svg viewBox="0 0 36 36">
-        <circle class="bg" cx="18" cy="18" r="16" />
-        <circle class="progress" cx="18" cy="18" r="16" />
-      </svg>
-      <span class="timer-number"></span>
-    </div>
     {% if title_text %}
-    <div class="sonic-title-pill {{ title_theme|default('default') }} ms-2">{{ title_text }}</div>
+    <div class="sonic-title-pill {{ title_theme|default('default') }} mx-2">{{ title_text }}</div>
     {% endif %}
     {% if profit_badge_value %}
     <span class="profit-badge badge text-bg-success ms-2">{{ profit_badge_value }}</span>
@@ -38,8 +31,15 @@
         <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="full"  title="Full Cycle"><span>🌪️</span></a>
         <a class="btn nav-icon-btn cyclone-btn" href="#" role="button" data-action="wipe"  title="Wipe All"><span>🗑️</span></a>
       </div>
+    <div id="refreshDial" class="refresh-dial ms-3" title="UI auto-refresh">
+      <svg viewBox="0 0 36 36">
+        <circle class="bg" cx="18" cy="18" r="16" />
+        <circle class="progress" cx="18" cy="18" r="16" />
+      </svg>
+      <span class="timer-number"></span>
+    </div>
     <div class="dropdown ms-3">
-      <a class="btn config-btn dropdown-toggle" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">
+      <a class="btn config-btn dropdown-toggle settings-btn" href="#" role="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Settings">
         <span>⚙️</span>
       </a>
       <ul class="dropdown-menu" aria-labelledby="settingsDropdown">


### PR DESCRIPTION
## Summary
- keep titles centered by removing left margin
- move refresh timer next to settings dropdown
- enlarge settings gear icon

## Testing
- `pytest -q` *(fails: 43 errors during collection)*