### PR TITLE
Fix title centering in title bar

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -7,14 +7,18 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.4rem 1.2rem;
+  position: relative;
 }
 .title-bar-center {
-  flex: 1 1 auto;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  text-align: center;
   font-size: 1.25rem;
   font-weight: 600;
+  pointer-events: none;
 }
 .nav-icon-btn {
   display: flex !important;

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -8,7 +8,7 @@
     <a class="btn nav-btn" href="/sonic_labs/hedge_report" title="Hedge Report"><span>🦔</span></a>
     <a class="btn nav-btn" href="/system/wallets" title="Wallet Manager"><span>💼</span></a>
   </div>
-  <div class="title-bar-center flex-grow-1 text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
+  <div class="title-bar-center text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
     {% if title_text %}
     <div class="sonic-title-pill {{ title_theme|default('default') }} mx-2">{{ title_text }}</div>
     {% endif %}


### PR DESCRIPTION
## Summary
- absolutely center the title text in the title bar

## Testing
- `pytest -q` *(fails: 43 errors during collection)*