### PR TITLE
Fix Hedge Labs table theme

### DIFF
--- a/static/css/hedge_labs.css
+++ b/static/css/hedge_labs.css
@@ -1,0 +1,26 @@
+.hedge-labs-table,
+#evalTable {
+  background: var(--container-bg);
+  color: var(--text);
+  width: 100%;
+}
+
+.hedge-labs-table thead th,
+#evalTable thead th {
+  background: var(--title-bar-bg);
+  color: var(--panel-title);
+  border-bottom: 2px solid var(--panel-border);
+  padding: 0.7em 0.6em;
+}
+
+.hedge-labs-table tbody td,
+#evalTable tbody td {
+  background: var(--container-bg);
+  color: var(--text);
+  border-bottom: 1px solid var(--panel-border);
+  padding: 0.7em 0.6em;
+}
+
+.hedge-labs-table.table-striped > tbody > tr:nth-of-type(odd) > * {
+  background-color: var(--accent);
+}

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/hedge_labs.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -27,7 +28,7 @@
         <i class="fas fa-sliders-h me-1"></i>Hedge Modifiers
       </a>
     </div>
-    <table class="table table-striped">
+    <table class="table table-striped hedge-labs-table">
       <thead>
         <tr>
           <th>Hedged Position</th>
@@ -77,7 +78,7 @@
         </div>
       </div>
     </div>
-    <table class="table table-sm" id="evalTable">
+    <table class="table table-sm hedge-labs-table" id="evalTable">
       <thead>
         <tr>
           <th><i class="fas fa-map-marker-alt me-1"></i>Position</th>


### PR DESCRIPTION
## Summary
- add Hedge Labs page css with theme colors for tables
- use new styling classes in template so table backgrounds follow the theme

## Testing
- `pytest -q` *(fails: 43 errors during collection)*