### PR TITLE
Integrate Jupiter collateral actions

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -188,6 +188,38 @@ def update_wallet(name):
     return redirect(url_for("system.list_wallets"))
 
 
+# 💵 Deposit collateral via Jupiter
+@system_bp.route("/wallets/jupiter/deposit", methods=["POST"])
+def deposit_collateral():
+    try:
+        wallet_name = request.form.get("wallet_name")
+        market = request.form.get("market")
+        amount = float(request.form.get("amount", 0.0))
+        wallet = get_core().wallets.get_wallet(wallet_name)
+        result = get_core().wallet_core.deposit_collateral(wallet, market, amount)
+        sig = result.get("txSig") if isinstance(result, dict) else result
+        flash(f"✅ Deposit transaction sent: {sig}", "success")
+    except Exception as e:
+        flash(f"❌ Deposit failed: {e}", "danger")
+    return redirect(url_for("system.list_wallets"))
+
+
+# 💸 Withdraw collateral via Jupiter
+@system_bp.route("/wallets/jupiter/withdraw", methods=["POST"])
+def withdraw_collateral():
+    try:
+        wallet_name = request.form.get("wallet_name")
+        market = request.form.get("market")
+        amount = float(request.form.get("amount", 0.0))
+        wallet = get_core().wallets.get_wallet(wallet_name)
+        result = get_core().wallet_core.withdraw_collateral(wallet, market, amount)
+        sig = result.get("txSig") if isinstance(result, dict) else result
+        flash(f"✅ Withdraw transaction sent: {sig}", "success")
+    except Exception as e:
+        flash(f"❌ Withdraw failed: {e}", "danger")
+    return redirect(url_for("system.list_wallets"))
+
+
 # === 🎨 Theme Profile Routes ===
 
 

--- a/templates/wallets/wallet_list.html
+++ b/templates/wallets/wallet_list.html
@@ -129,6 +129,54 @@
   </div>
 </div>
 
+<div class="sonic-section-container sonic-section-middle mt-3">
+  <div class="sonic-content-panel">
+    <div class="section-title">Jupiter Collateral</div>
+    <form action="{{ url_for('system.deposit_collateral') }}" method="post" class="row g-2 align-items-end">
+      <div class="col-md-4">
+        <label class="form-label">Wallet</label>
+        <select name="wallet_name" class="form-select">
+          {% for w in wallets %}
+          <option value="{{ w.name }}">{{ w.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Market</label>
+        <input type="text" name="market" class="form-control" placeholder="SOL-PERP">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Amount</label>
+        <input type="number" step="0.0001" name="amount" class="form-control">
+      </div>
+      <div class="col-md-2 text-end">
+        <button type="submit" class="btn btn-success w-100">Deposit</button>
+      </div>
+    </form>
+    <form action="{{ url_for('system.withdraw_collateral') }}" method="post" class="row g-2 align-items-end mt-2">
+      <div class="col-md-4">
+        <label class="form-label">Wallet</label>
+        <select name="wallet_name" class="form-select">
+          {% for w in wallets %}
+          <option value="{{ w.name }}">{{ w.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Market</label>
+        <input type="text" name="market" class="form-control" placeholder="SOL-PERP">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Amount</label>
+        <input type="number" step="0.0001" name="amount" class="form-control">
+      </div>
+      <div class="col-md-2 text-end">
+        <button type="submit" class="btn btn-warning w-100">Withdraw</button>
+      </div>
+    </form>
+  </div>
+</div>
+
   <!-- Edit Wallet Modal -->
   <div class="modal fade" id="editWalletModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered">

--- a/wallets/jupiter_service.py
+++ b/wallets/jupiter_service.py
@@ -1,0 +1,53 @@
+"""JupiterService
+===============
+Utility wrapper for interacting with Jupiter Perpetuals API.
+"""
+from __future__ import annotations
+
+import requests
+
+from core.logging import log
+from core.constants import JUPITER_API_BASE
+
+
+class JupiterService:
+    """Simple HTTP client for Jupiter collateral endpoints."""
+
+    def __init__(self, api_base: str = JUPITER_API_BASE):
+        self.api_base = api_base.rstrip("/")
+
+    def increase_position(self, wallet: str, market: str, collateral_delta: float) -> dict:
+        """Call Jupiter's increasePosition endpoint."""
+        url = f"{self.api_base}/v1/increase_position"
+        payload = {
+            "wallet": wallet,
+            "market": market,
+            "collateral_delta": collateral_delta,
+            "size_usd_delta": 0,
+        }
+        log.debug(f"POST {url} {payload}", source="JupiterService")
+        try:
+            res = requests.post(url, json=payload, timeout=10)
+            res.raise_for_status()
+            return res.json()
+        except Exception as exc:  # pragma: no cover - network failures
+            log.error(f"IncreasePosition failed: {exc}", source="JupiterService")
+            raise
+
+    def decrease_position(self, wallet: str, market: str, collateral_delta: float) -> dict:
+        """Call Jupiter's decreasePosition endpoint."""
+        url = f"{self.api_base}/v1/decrease_position"
+        payload = {
+            "wallet": wallet,
+            "market": market,
+            "collateral_delta": collateral_delta,
+            "size_usd_delta": 0,
+        }
+        log.debug(f"POST {url} {payload}", source="JupiterService")
+        try:
+            res = requests.post(url, json=payload, timeout=10)
+            res.raise_for_status()
+            return res.json()
+        except Exception as exc:  # pragma: no cover - network failures
+            log.error(f"DecreasePosition failed: {exc}", source="JupiterService")
+            raise


### PR DESCRIPTION
## Summary
- hook up Jupiter collateral endpoints via a new `JupiterService`
- extend `WalletCore` with deposit/withdraw helpers
- expose deposit/withdraw routes in `system_bp`
- add Jupiter collateral control panel to wallet UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*