### PR TITLE
Fix short table icons

### DIFF
--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -62,3 +62,28 @@ th.sorted-desc .sort-indicator { color: var(--primary); }
   padding: 1.2rem;
   font-style: italic;
 }
+
+/* Outer borders for tables */
+#short-table {
+  border-left: var(--panel-border-width) solid var(--panel-border);
+  border-top: var(--panel-border-width) solid var(--panel-border);
+  border-bottom: var(--panel-border-width) solid var(--panel-border);
+}
+
+#long-table {
+  border-right: var(--panel-border-width) solid var(--panel-border);
+  border-top: var(--panel-border-width) solid var(--panel-border);
+  border-bottom: var(--panel-border-width) solid var(--panel-border);
+}
+
+/* Thick separator between size columns */
+.positions-table th.size-col,
+.positions-table td.size-col {
+  border-right: calc(2 * var(--panel-border-width)) solid var(--panel-border);
+}
+
+#long-table th.size-col,
+#long-table td.size-col {
+  border-left: calc(2 * var(--panel-border-width)) solid var(--panel-border);
+  border-right: none;
+}

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -34,7 +34,7 @@
               <th class="sortable right" data-col-index="2">Value <span class="sort-indicator"></span></th>
               <th class="sortable right" data-col-index="3">Leverage <span class="sort-indicator"></span></th>
               <th class="sortable right" data-col-index="4">Travel % <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="5">Size <span class="sort-indicator"></span></th>
+              <th class="sortable right size-col" data-col-index="5">Size <span class="sort-indicator"></span></th>
             </tr>
           </thead>
           <tbody>
@@ -45,11 +45,6 @@
                 <tr class="no-data-row"><td colspan="6" class="no-data">No data</td></tr>
               {% else %}
                 <tr>
-                  <td class="right">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
-                  <td class="right">{{ pos.travel_percent|float|round(2) }}%</td>
-                  <td class="right">{{ pos.leverage|float|round(2) }}</td>
-                  <td class="right">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
-                  <td class="right">{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
                   <td class="left">
                     <span class="icon-inline">
                       {% if pos.asset == "BTC" %}
@@ -62,6 +57,11 @@
                       {{ pos.asset }}
                     </span>
                   </td>
+                  <td class="right">{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
+                  <td class="right">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
+                  <td class="right">{{ pos.leverage|float|round(2) }}</td>
+                  <td class="right">{{ pos.travel_percent|float|round(2) }}%</td>
+                  <td class="right size-col">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
                 </tr>
               {% endif %}
             {% endfor %}
@@ -89,7 +89,7 @@
               <td class="right">{{ "{:,}".format(short_totals.get('value',0)|float|round(2)) }}</td>
               <td class="right">{{ short_totals.get('leverage',0)|float|round(2) }}</td>
               <td class="right">{{ short_totals.get('travel_percent',0)|float|round(2) }}%</td>
-              <td class="right">{{ "{:,}".format(short_totals.get('size',0)|float|round(2)) }}</td>
+              <td class="right size-col">{{ "{:,}".format(short_totals.get('size',0)|float|round(2)) }}</td>
             </tr>
           </tfoot>
         </table>
@@ -102,7 +102,7 @@
         <table id="long-table" class="positions-table">
           <thead>
             <tr>
-              <th class="sortable right" data-col-index="0">Size <span class="sort-indicator"></span></th>
+              <th class="sortable right size-col" data-col-index="0">Size <span class="sort-indicator"></span></th>
               <th class="sortable right" data-col-index="1">Travel % <span class="sort-indicator"></span></th>
               <th class="sortable right" data-col-index="2">Leverage <span class="sort-indicator"></span></th>
               <th class="sortable right" data-col-index="3">Value <span class="sort-indicator"></span></th>
@@ -118,7 +118,7 @@
                 <tr class="no-data-row"><td colspan="6" class="no-data">No data</td></tr>
               {% else %}
                 <tr>
-                  <td class="right">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
+                  <td class="right size-col">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
                   <td class="right">{{ pos.travel_percent|float|round(2) }}%</td>
                   <td class="right">{{ pos.leverage|float|round(2) }}</td>
                   <td class="right">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
@@ -142,7 +142,7 @@
           <tfoot>
             <tr class="fw-bold">
               {% set long_totals = hd.get('totals', {}).get('long', {}) %}
-              <td class="right">{{ "{:,}".format(long_totals.get('size',0)|float|round(2)) }}</td>
+              <td class="right size-col">{{ "{:,}".format(long_totals.get('size',0)|float|round(2)) }}</td>
               <td class="right">{{ long_totals.get('travel_percent',0)|float|round(2) }}%</td>
               <td class="right">{{ long_totals.get('leverage',0)|float|round(2) }}</td>
               <td class="right">{{ "{:,}".format(long_totals.get('value',0)|float|round(2)) }}</td>


### PR DESCRIPTION
## Summary
- fix short table column order so asset icons appear on the left
- add thick separator between size columns and outer borders for hedge tables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*