### PR TITLE
Update dashboard title

### DIFF
--- a/static/css/sonic_titles.css
+++ b/static/css/sonic_titles.css
@@ -28,3 +28,7 @@
   background: #7c3aed;
   color: #fff;
 }
+
+.sonic-title-image {
+  height: 1.5rem;
+}

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -15,7 +15,8 @@
 
 {% block content %}
 
-  {% set title_text = 'Dashboard' %}
+  {% set title_image = url_for('static', filename='images/sonic_title') %}
+  {% set title_text = None %}
   {% set title_theme = 'dashboard' %}
   {# Older Jinja versions do not support passing variables with the
      `include` statement. We set the variables above and rely on the

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -9,7 +9,11 @@
     <a class="btn nav-btn" href="/system/wallets" title="Wallet Manager"><span>💼</span></a>
   </div>
   <div class="title-bar-center text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
-    {% if title_text %}
+    {% if title_image %}
+    <div class="sonic-title-pill {{ title_theme|default('default') }} mx-2">
+      <img src="{{ title_image }}" alt="{{ title_text or 'title' }}" class="sonic-title-image">
+    </div>
+    {% elif title_text %}
     <div class="sonic-title-pill {{ title_theme|default('default') }} mx-2">{{ title_text }}</div>
     {% endif %}
     {% if profit_badge_value %}


### PR DESCRIPTION
## Summary
- allow an image in the title bar
- add styling for a title image
- show `/static/images/sonic_title` image on the dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*