### PR TITLE
Fix hedge report data filtering and alignment

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -431,7 +431,11 @@ def hedge_calculator_page():
     """Render the hedge calculator page."""
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_active_positions() or []
+        positions = [
+            p
+            for p in (core.get_active_positions() or [])
+            if str(p.get("status", "")).upper() == "ACTIVE"
+        ]
 
         long_positions = [
             p for p in positions if str(p.get("position_type", "")).upper() == "LONG"
@@ -486,7 +490,11 @@ def hedge_report_page():
     """Render the hedge report page with aggregated long/short data."""
     try:
         core = PositionCore(current_app.data_locker)
-        positions = core.get_active_positions() or []
+        positions = [
+            p
+            for p in (core.get_active_positions() or [])
+            if str(p.get("status", "")).upper() == "ACTIVE"
+        ]
 
         def build(group_positions, asset_name):
             from calc_core.calc_services import CalcServices

--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -29,6 +29,8 @@
 .positions-table td.left { text-align: left; }
 .positions-table th.right,
 .positions-table td.right { text-align: right; }
+.positions-table th.center,
+.positions-table td.center { text-align: center; }
 
 .positions-table tbody td {
   background: var(--container-bg);
@@ -46,6 +48,7 @@
   text-align: right;
 }
 .positions-table tfoot td.left { text-align: left; }
+.positions-table tfoot td.center { text-align: center; }
 
 .sort-indicator {
   font-size: 1em;

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -30,11 +30,11 @@
           <thead>
             <tr>
               <th class="sortable left" data-col-index="0">Asset <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="1">Collateral <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="2">Value <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="3">Leverage <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="4">Travel % <span class="sort-indicator"></span></th>
-              <th class="sortable right size-col" data-col-index="5">Size <span class="sort-indicator"></span></th>
+              <th class="sortable center" data-col-index="1">Collateral <span class="sort-indicator"></span></th>
+              <th class="sortable center" data-col-index="2">Value <span class="sort-indicator"></span></th>
+              <th class="sortable center" data-col-index="3">Leverage <span class="sort-indicator"></span></th>
+              <th class="sortable center" data-col-index="4">Travel % <span class="sort-indicator"></span></th>
+              <th class="sortable center size-col" data-col-index="5">Size <span class="sort-indicator"></span></th>
             </tr>
           </thead>
           <tbody>
@@ -57,11 +57,11 @@
                       {{ pos.asset }}
                     </span>
                   </td>
-                  <td class="right">{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
-                  <td class="right">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
-                  <td class="right">{{ pos.leverage|float|round(2) }}</td>
-                  <td class="right">{{ pos.travel_percent|float|round(2) }}%</td>
-                  <td class="right size-col">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
+                  <td class="center">{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
+                  <td class="center">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
+                  <td class="center">{{ pos.leverage|float|round(2) }}</td>
+                  <td class="center">{{ pos.travel_percent|float|round(2) }}%</td>
+                  <td class="center size-col">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
                 </tr>
               {% endif %}
             {% endfor %}
@@ -85,11 +85,11 @@
                   {% endif %}
                 </span>
               </td>
-              <td class="right">{{ "{:,}".format(short_totals.get('collateral',0)|float|round(2)) }}</td>
-              <td class="right">{{ "{:,}".format(short_totals.get('value',0)|float|round(2)) }}</td>
-              <td class="right">{{ short_totals.get('leverage',0)|float|round(2) }}</td>
-              <td class="right">{{ short_totals.get('travel_percent',0)|float|round(2) }}%</td>
-              <td class="right size-col">{{ "{:,}".format(short_totals.get('size',0)|float|round(2)) }}</td>
+              <td class="center">{{ "{:,}".format(short_totals.get('collateral',0)|float|round(2)) }}</td>
+              <td class="center">{{ "{:,}".format(short_totals.get('value',0)|float|round(2)) }}</td>
+              <td class="center">{{ short_totals.get('leverage',0)|float|round(2) }}</td>
+              <td class="center">{{ short_totals.get('travel_percent',0)|float|round(2) }}%</td>
+              <td class="center size-col">{{ "{:,}".format(short_totals.get('size',0)|float|round(2)) }}</td>
             </tr>
           </tfoot>
         </table>
@@ -102,11 +102,11 @@
         <table id="long-table" class="positions-table">
           <thead>
             <tr>
-              <th class="sortable right size-col" data-col-index="0">Size <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="1">Travel % <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="2">Leverage <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="3">Value <span class="sort-indicator"></span></th>
-              <th class="sortable right" data-col-index="4">Collateral <span class="sort-indicator"></span></th>
+              <th class="sortable center size-col" data-col-index="0">Size <span class="sort-indicator"></span></th>
+              <th class="sortable center" data-col-index="1">Travel % <span class="sort-indicator"></span></th>
+              <th class="sortable center" data-col-index="2">Leverage <span class="sort-indicator"></span></th>
+              <th class="sortable center" data-col-index="3">Value <span class="sort-indicator"></span></th>
+              <th class="sortable center" data-col-index="4">Collateral <span class="sort-indicator"></span></th>
               <th class="sortable left" data-col-index="5">Asset <span class="sort-indicator"></span></th>
             </tr>
           </thead>
@@ -118,11 +118,11 @@
                 <tr class="no-data-row"><td colspan="6" class="no-data">No data</td></tr>
               {% else %}
                 <tr>
-                  <td class="right size-col">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
-                  <td class="right">{{ pos.travel_percent|float|round(2) }}%</td>
-                  <td class="right">{{ pos.leverage|float|round(2) }}</td>
-                  <td class="right">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
-                  <td class="right">{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
+                  <td class="center size-col">{{ "{:,}".format(pos.size|float|round(2)) }}</td>
+                  <td class="center">{{ pos.travel_percent|float|round(2) }}%</td>
+                  <td class="center">{{ pos.leverage|float|round(2) }}</td>
+                  <td class="center">{{ "{:,}".format(pos.value|float|round(2)) }}</td>
+                  <td class="center">{{ "{:,}".format(pos.collateral|float|round(2)) }}</td>
                   <td class="left">
                     <span class="icon-inline">
                       {% if pos.asset == "BTC" %}
@@ -142,11 +142,11 @@
           <tfoot>
             <tr class="fw-bold">
               {% set long_totals = hd.get('totals', {}).get('long', {}) %}
-              <td class="right size-col">{{ "{:,}".format(long_totals.get('size',0)|float|round(2)) }}</td>
-              <td class="right">{{ long_totals.get('travel_percent',0)|float|round(2) }}%</td>
-              <td class="right">{{ long_totals.get('leverage',0)|float|round(2) }}</td>
-              <td class="right">{{ "{:,}".format(long_totals.get('value',0)|float|round(2)) }}</td>
-              <td class="right">{{ "{:,}".format(long_totals.get('collateral',0)|float|round(2)) }}</td>
+              <td class="center size-col">{{ "{:,}".format(long_totals.get('size',0)|float|round(2)) }}</td>
+              <td class="center">{{ long_totals.get('travel_percent',0)|float|round(2) }}%</td>
+              <td class="center">{{ long_totals.get('leverage',0)|float|round(2) }}</td>
+              <td class="center">{{ "{:,}".format(long_totals.get('value',0)|float|round(2)) }}</td>
+              <td class="center">{{ "{:,}".format(long_totals.get('collateral',0)|float|round(2)) }}</td>
               <td class="left">
                 {% if long_totals.get('asset') %}
                   <span class="icon-inline">


### PR DESCRIPTION
## Summary
- filter hedge report data by ACTIVE status
- center values on the hedge report tables

## Testing
- `pytest -q` *(fails: 43 errors during collection)*