### PR TITLE
Fix alert config disable logic and add tests

### DIFF
--- a/alert_core/alert_store.py
+++ b/alert_core/alert_store.py
@@ -235,9 +235,9 @@ class AlertStore:
                 ]
 
                 for spec in alerts:
-                    metric_cfg = pos_cfg.get(spec["description"], {})
+                    metric_cfg = pos_cfg.get(spec["description"])
                     # Skip alert creation if explicitly disabled or key is missing
-                    if not metric_cfg.get("enabled", True):
+                    if not metric_cfg or not metric_cfg.get("enabled", False):
                         continue
 
                     trig_val = metric_cfg.get("medium", spec["trigger_value"])
@@ -295,9 +295,9 @@ class AlertStore:
         ]
 
         for alert_type, description, trigger_value, condition in metrics:
-            metric_cfg = port_cfg.get(description, {})
+            metric_cfg = port_cfg.get(description)
             # Skip when disabled or missing in config
-            if not metric_cfg.get("enabled", True):
+            if not metric_cfg or not metric_cfg.get("enabled", False):
                 continue
 
             trig_val = metric_cfg.get("medium", trigger_value)

--- a/tests/test_alert_disabled_creation.py
+++ b/tests/test_alert_disabled_creation.py
@@ -1,0 +1,65 @@
+import pytest
+from data.data_locker import DataLocker
+from alert_core.alert_store import AlertStore
+
+
+def _insert_position(dl):
+    pos = {
+        "id": "pos1",
+        "asset_type": "BTC",
+        "entry_price": 100.0,
+        "liquidation_price": 50.0,
+        "position_type": "LONG",
+        "wallet_name": "test",
+        "current_heat_index": 0.0,
+        "pnl_after_fees_usd": 0.0,
+        "travel_percent": 0.0,
+        "liquidation_distance": 0.0,
+    }
+    dl.positions.insert_position(pos)
+
+
+def test_position_alert_respects_disabled(tmp_path):
+    db_path = tmp_path / "alerts.db"
+    dl = DataLocker(str(db_path))
+    _insert_position(dl)
+
+    def cfg():
+        return {
+            "alert_ranges": {
+                "positions_alerts": {
+                    "heat_index": {"enabled": False},
+                    "travel_percent": {"enabled": True, "medium": 5},
+                    # profit intentionally missing
+                }
+            }
+        }
+
+    store = AlertStore(dl, cfg)
+    store.create_position_alerts()
+
+    alerts = dl.db.fetch_all("alerts")
+    types = {a["alert_type"] for a in alerts}
+    assert types == {"TravelPercentLiquid"}
+
+
+def test_portfolio_alert_respects_disabled(tmp_path):
+    db_path = tmp_path / "alerts2.db"
+    dl = DataLocker(str(db_path))
+
+    def cfg():
+        return {
+            "alert_ranges": {
+                "portfolio_alerts": {
+                    "total_value": {"enabled": False},
+                    "total_size": {"enabled": True, "medium": 2},
+                }
+            }
+        }
+
+    store = AlertStore(dl, cfg)
+    store.create_portfolio_alerts()
+
+    alerts = dl.db.fetch_all("alerts")
+    types = {a["alert_type"] for a in alerts}
+    assert types == {"TotalSize"}


### PR DESCRIPTION
## Summary
- ensure alert creation skips metrics missing or disabled in config
- add tests covering disabled alert creation for position and portfolio alerts

## Testing
- `pytest -q tests/test_alert_disabled_creation.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*