### PR TITLE
Update default title image

### DIFF
--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -15,8 +15,6 @@
 
 {% block content %}
 
-  {% set title_image = url_for('static', filename='images/sonic_title') %}
-  {% set title_text = None %}
   {% set title_theme = 'dashboard' %}
   {# Older Jinja versions do not support passing variables with the
      `include` statement. We set the variables above and rely on the

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -1,5 +1,6 @@
 <div id="toastContainer" class="toast-container" style="position: fixed; top: 1.5rem; right: 2rem; z-index: 3000;"></div>
 <nav class="title-bar d-flex justify-content-between align-items-center px-3 py-2">
+  {% set title_image = title_image|default(url_for('static', filename='images/sonic_title.png')) %}
   <div class="nav-bar d-flex align-items-center gap-2">
     <a class="btn nav-btn" href="/" title="Home"><span>🏠</span></a>
     <a class="btn nav-btn" href="{{ url_for('positions.list_positions') }}" title="Positions"><span>📊</span></a>


### PR DESCRIPTION
## Summary
- default `title_bar` image to `/static/images/sonic_title.png`
- simplify `sonic_dashboard.html` to rely on default title image

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*