### PR TITLE
Read alert limits from DB

### DIFF
--- a/alert_core/alert_store.py
+++ b/alert_core/alert_store.py
@@ -54,7 +54,12 @@ class AlertStore:
         """
 
         self.data_locker = data_locker
-        self.config_loader = config_loader or (lambda: {})
+        if config_loader:
+            self.config_loader = config_loader
+        else:
+            self.config_loader = (
+                lambda: self.data_locker.system.get_var("alert_limits") or {}
+            )
 
     @staticmethod
     def initialize_alert_data(alert_data: dict = None) -> dict:

--- a/app/alerts_bp.py
+++ b/app/alerts_bp.py
@@ -5,13 +5,10 @@ import asyncio
 import os
 from types import SimpleNamespace
 from flask import current_app
-from config.config_loader import load_config
-from core.core_imports import ALERT_LIMITS_PATH
 from alert_core.alert_utils import resolve_wallet_metadata
 from dashboard.dashboard_service import WALLET_IMAGE_MAP, DEFAULT_WALLET_IMAGE
 
 from flask import Blueprint, jsonify, render_template, render_template_string, request, session
-from data.data_locker import DataLocker
 from config.config_loader import update_config as merge_config
 
 APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app'))
@@ -139,7 +136,7 @@ def alert_config_page():
 
     """Render the alert limits configuration page with config data."""
     try:
-        config_data = load_config(str(ALERT_LIMITS_PATH)) or {}
+        config_data = current_app.data_locker.system.get_var("alert_limits") or {}
         alert_ranges = config_data.get("alert_ranges", {})
         price_alerts = alert_ranges.get("price_alerts", {})
         portfolio_alerts = alert_ranges.get("portfolio_alerts", {})
@@ -273,7 +270,7 @@ def update_config():
         parsed = _parse_nested_form(form_data)
         parsed = convert_types_in_dict(parsed)
 
-        merge_config(parsed, str(ALERT_LIMITS_PATH))
+        merge_config(parsed)
 
         return jsonify({"success": True, "message": "Configuration updated"})
     except Exception as e:

--- a/app/positions_bp.py
+++ b/app/positions_bp.py
@@ -13,8 +13,6 @@ from positions.position_core import PositionCore
 from calc_core.calculation_core import CalculationCore
 from calc_core.calc_services import CalcServices
 from utils.route_decorators import route_log_alert
-from config.config_loader import load_config
-from core.constants import ALERT_LIMITS_PATH
 
 
 positions_bp = Blueprint("positions", __name__, template_folder="../templates/positions")
@@ -42,7 +40,7 @@ def list_positions():
         core = PositionCore(current_app.data_locker)
         positions = core.get_active_positions()
 
-        config_data = load_config(str(ALERT_LIMITS_PATH)) or {}
+        config_data = current_app.data_locker.system.get_var("alert_limits") or {}
         alert_dict = config_data.get("alert_ranges", {})
 
         def get_alert_class(value, low, med, high):

--- a/cyclone/cyclone_engine.py
+++ b/cyclone/cyclone_engine.py
@@ -11,8 +11,6 @@ from alert_core.alert_core import AlertCore #alert_service_manager import AlertS
 from data.data_locker import DataLocker
 from core.constants import DB_PATH
 from core.logging import log
-from core.constants import DB_PATH, ALERT_LIMITS_PATH
-from config.config_loader import load_config
 
 # PATCH: Import SystemCore for death screams
 from system.system_core import SystemCore
@@ -76,7 +74,7 @@ class Cyclone:
 
         self.data_locker = global_data_locker
         self.price_sync = PriceSyncService(self.data_locker)
-        self.config = load_config(str(ALERT_LIMITS_PATH))
+        self.config = self.data_locker.system.get_var("alert_limits") or {}
 
         self.position_core = PositionCore(self.data_locker)
         # Pass alert limits config to AlertCore so alert creation respects


### PR DESCRIPTION
## Summary
- get alert config from database by default
- let AlertCore/AlertStore use DB-backed config loader
- update UI endpoints to read/update DB config
- fetch DB config in Cyclone engine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*