### PR TITLE
Remove default title image

### DIFF
--- a/static/css/sonic_titles.css
+++ b/static/css/sonic_titles.css
@@ -8,7 +8,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
+  padding: 0.3rem 1.4rem;
   font-family: 'Orbitron', sans-serif;
   font-size: 1.15rem;
   font-weight: 600;
@@ -17,7 +17,6 @@
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
-  transform: scale(1.5);
 }
 
 .sonic-title-pill.default {
@@ -31,7 +30,5 @@
 }
 
 .sonic-title-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: 1.5rem;
 }

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -1,6 +1,5 @@
 <div id="toastContainer" class="toast-container" style="position: fixed; top: 1.5rem; right: 2rem; z-index: 3000;"></div>
 <nav class="title-bar d-flex justify-content-between align-items-center px-3 py-2">
-  {% set title_image = title_image|default(url_for('static', filename='images/sonic_title.png')) %}
   <div class="nav-bar d-flex align-items-center gap-2">
     <a class="btn nav-btn" href="/" title="Home"><span>🏠</span></a>
     <a class="btn nav-btn" href="{{ url_for('positions.list_positions') }}" title="Positions"><span>📊</span></a>


### PR DESCRIPTION
## Summary
- use string titles instead of default image in `title_bar.html`
- restore padding in `.sonic-title-pill` and simplify `.sonic-title-image` style

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*