### PR TITLE
Add title bar shimmer effect

### DIFF
--- a/static/css/sonic_titles.css
+++ b/static/css/sonic_titles.css
@@ -17,6 +17,27 @@
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.sonic-title-pill.shimmer {
+  color: #fff;
+  background: linear-gradient(90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    rgba(255, 255, 255, 0) 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.8s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
 }
 
 .sonic-title-pill.default {

--- a/static/js/title_bar.js
+++ b/static/js/title_bar.js
@@ -102,4 +102,10 @@ document.addEventListener('DOMContentLoaded', () => {
       setTheme(themeIndex);
     });
   }
+
+  // Apply shimmer animation to the title pill on load
+  const titlePill = document.querySelector('.sonic-title-pill');
+  if (titlePill) {
+    titlePill.classList.add('shimmer');
+  }
 });


### PR DESCRIPTION
## Summary
- add `shimmer` animation CSS for title bar text
- apply shimmer class on DOM load in `title_bar.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*