### PR TITLE
Improve DB_PATH handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,17 @@ To create the SQLite database and all required tables, run:
 python scripts/init_db.py
 ```
 
-The script creates `mother_brain.db` in the `data` directory (or the path set via
-the `DB_PATH` environment variable) and ensures every table exists.  Additional
-flags allow optional seeding and resets:
+The script creates `mother_brain.db` in the `data` directory by default. Set the
+`DB_PATH` environment variable to override this location before running the
+script:
+
+```bash
+export DB_PATH=/path/to/your/mother_brain.db
+python scripts/init_db.py
+```
+
+The initializer ensures every table exists.  Additional flags allow optional
+seeding and resets:
 
 ```bash
 # wipe the DB and seed thresholds and wallets

--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -7,7 +7,7 @@ from typing import Optional
 from data.models import AlertThreshold
 from data.data_locker import DataLocker
 from positions.position_core import PositionCore
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 from cyclone.cyclone_engine import Cyclone
 
 from datetime import datetime

--- a/app/prices_bp.py
+++ b/app/prices_bp.py
@@ -23,7 +23,8 @@ from flask import Blueprint, request, jsonify, render_template, redirect, url_fo
 # Import configuration constants and modules
 from data.data_locker import DataLocker
 from monitor.price_monitor import PriceMonitor
-from core.core_imports import CONFIG_PATH, DB_PATH, retry_on_locked
+from core.core_imports import CONFIG_PATH, retry_on_locked
+from core.constants import DB_PATH
 
 
 # ---------------------------------------------------------------------------

--- a/core/constants.py
+++ b/core/constants.py
@@ -31,7 +31,8 @@ MONITOR_DIR = BASE_DIR / "monitor"
 # 📁 Core File Paths
 # -----------------------------
 DB_FILENAME = os.getenv("DB_FILENAME", "mother_brain.db")
-DB_PATH = DATA_DIR / DB_FILENAME
+# Allow environment override for the full database path
+DB_PATH = Path(os.getenv("DB_PATH", DATA_DIR / DB_FILENAME))
 
 CONFIG_PATH = CONFIG_DIR / os.getenv("CONFIG_FILENAME", "sonic_config.json")
 ALERT_LIMITS_PATH = CONFIG_DIR / os.getenv("ALERT_LIMITS_FILENAME", "alert_limits.json")

--- a/core/core_imports.py
+++ b/core/core_imports.py
@@ -5,12 +5,6 @@ Use this instead of importing from `core/__init__.py`.
 """
 import os
 
-# Absolute path to /data/mother_brain.db with env override
-DB_PATH = os.getenv(
-    "DB_PATH",
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data", "mother_brain.db"))
-)
-
 from core.logging import log, configure_console_log
 #from core.locker_factory import get_locker
 from core.constants import DB_PATH, CONFIG_PATH, BASE_DIR, ALERT_LIMITS_PATH

--- a/cyclone/cyclone_console/commands/alerts.py
+++ b/cyclone/cyclone_console/commands/alerts.py
@@ -4,7 +4,8 @@ import typer
 from rich.table import Table
 from rich.console import Console
 from cyclone.cyclone_alert_service import CycloneAlertService
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 
 app = typer.Typer(help="🔔 Alert tools: view, enrich, evaluate")

--- a/cyclone/cyclone_console/commands/hedge.py
+++ b/cyclone/cyclone_console/commands/hedge.py
@@ -3,7 +3,8 @@
 import typer
 from rich.console import Console
 from rich.table import Table
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 # HedgeManager lives under positions. Import it from there so the CLI works.
 from positions.hedge_manager import HedgeManager

--- a/cyclone/cyclone_console/commands/portfolio.py
+++ b/cyclone/cyclone_console/commands/portfolio.py
@@ -5,7 +5,8 @@ from rich.console import Console
 from rich.table import Table
 from cyclone.cyclone_portfolio_service import CyclonePortfolioService
 from positions.position_core_service import PositionCoreService
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 
 app = typer.Typer(help="📦 Portfolio tools")

--- a/cyclone/cyclone_console/commands/positions.py
+++ b/cyclone/cyclone_console/commands/positions.py
@@ -3,7 +3,8 @@
 import typer
 from rich.table import Table
 from rich.console import Console
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 from cyclone.cyclone_position_service import CyclonePositionService
 from core.logging import log

--- a/cyclone/cyclone_console/commands/prices.py
+++ b/cyclone/cyclone_console/commands/prices.py
@@ -6,7 +6,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import typer
 from rich.table import Table
 from rich.console import Console
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 from monitor.price_monitor import PriceMonitor
 

--- a/cyclone/cyclone_console/commands/system.py
+++ b/cyclone/cyclone_console/commands/system.py
@@ -3,7 +3,8 @@
 import typer
 from rich.console import Console
 from cyclone.cyclone_engine import Cyclone
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 
 app = typer.Typer(help="🧹 System operations: wipe, reset, maintenance")

--- a/cyclone/cyclone_console/utils/cli_renderer - Copy.py
+++ b/cyclone/cyclone_console/utils/cli_renderer - Copy.py
@@ -3,7 +3,8 @@
 import typer
 from rich.console import Console
 from cyclone_engine import Cyclone
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 
 from cyclone_console.utils.cli_renderer import banner, print_success, print_warning, print_error

--- a/cyclone/cyclone_portfolio_service.py
+++ b/cyclone/cyclone_portfolio_service.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from data.data_locker import DataLocker
 from data.alert import AlertType, Condition
 from alert_core.alert_utils import log_alert_summary
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 from core.logging import log
 
 

--- a/cyclone/cyclone_report_generator.py
+++ b/cyclone/cyclone_report_generator.py
@@ -4,7 +4,7 @@ import datetime
 import requests
 import sqlite3
 from core.constants import LOG_DATE_FORMAT, LOG_DIR  # Import LOG_DIR
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 
 def query_update_ledger():
     """

--- a/cyclone_app.py
+++ b/cyclone_app.py
@@ -6,7 +6,8 @@ from rich.prompt import Prompt
 from rich.table import Table
 from cyclone.cyclone_engine import Cyclone
 from monitor.monitor_core import MonitorCore
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 
 console = Console()

--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -10,14 +10,15 @@ from xcom.xcom_core import get_latest_xcom_monitor_entry
 #from monitor.ledger_service import LedgerService
 
 from data.data_locker import DataLocker
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 from alert_core.threshold_service import ThresholdService
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from system.system_core import SystemCore
 from utils.fuzzy_wuzzy import fuzzy_match_key
 from calc_core.calculation_core import CalculationCore
-from core.core_imports import ALERT_LIMITS_PATH, DB_PATH
+from core.core_imports import ALERT_LIMITS_PATH
+from core.constants import DB_PATH
 
 # Mapping of wallet names to icon filenames
 WALLET_IMAGE_MAP = {

--- a/data/insert_wallets.py
+++ b/data/insert_wallets.py
@@ -4,7 +4,8 @@ import sqlite3
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from core.core_imports import DB_PATH, configure_console_log
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 
 def ensure_wallets_table(db):

--- a/hedge_core_console.py
+++ b/hedge_core_console.py
@@ -3,7 +3,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 from hedge_core.hedge_core import HedgeCore
 

--- a/monitor/base_monitor.py
+++ b/monitor/base_monitor.py
@@ -7,7 +7,7 @@ class BaseMonitor:
     def run_cycle(self):
         from core.logging import log
         from data.data_locker import DataLocker
-        from core.core_imports import DB_PATH
+        from core.constants import DB_PATH
 
         log.banner(f"🚀 Running {self.name}")
         result = {}

--- a/monitor/monitor_console.py
+++ b/monitor/monitor_console.py
@@ -20,11 +20,10 @@ from core.logging import log
 
 from utils.console_logger import ConsoleLogger as log
 from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 
 from data.data_locker import DataLocker
 
-# ✅ Resolve correct DB path
-DB_PATH = os.getenv("DB_PATH", os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data", "mother_brain.db")))
 configure_console_log()
 data_locker = DataLocker(DB_PATH)
 ledger = data_locker.ledger

--- a/monitor/position_monitor.py
+++ b/monitor/position_monitor.py
@@ -4,7 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from monitor.base_monitor import BaseMonitor
 from data.data_locker import DataLocker
 from positions.position_core import PositionCore
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 from datetime import datetime, timezone
 from core.logging import log
 

--- a/monitor/price_monitor.py
+++ b/monitor/price_monitor.py
@@ -7,7 +7,7 @@ from prices.price_sync_service import PriceSyncService
 from data.data_locker import DataLocker
 from monitor.base_monitor import BaseMonitor
 from monitor.monitor_service import MonitorService
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 
 from datetime import datetime, timezone
 from core.logging import log

--- a/monitor/twilio_monitor.py
+++ b/monitor/twilio_monitor.py
@@ -6,7 +6,7 @@ from monitor.base_monitor import BaseMonitor
 from data.data_locker import DataLocker
 from xcom.xcom_config_service import XComConfigService
 from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 
 
 class TwilioMonitor(BaseMonitor):

--- a/monitor/xcom_monitor.py
+++ b/monitor/xcom_monitor.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from monitor.base_monitor import BaseMonitor
 from data.data_locker import DataLocker
 from xcom.xcom_core import XComCore
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 from core.logging import log
 
 

--- a/operations_console.py
+++ b/operations_console.py
@@ -7,7 +7,8 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 from core.logging import log
 
 from utils.console_logger import ConsoleLogger as log
-from core.core_imports import configure_console_log, DB_PATH
+from core.core_imports import configure_console_log
+from core.constants import DB_PATH
 
 from data.data_locker import DataLocker
 from xcom.xcom_core import XComCore

--- a/positions/hedge_manager.py
+++ b/positions/hedge_manager.py
@@ -20,7 +20,7 @@ from typing import List, Optional, TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from data.data_locker import DataLocker
 from data.models import Hedge
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 from hedge_core.hedge_core import HedgeCore
 
 

--- a/sonic_app.py
+++ b/sonic_app.py
@@ -14,7 +14,8 @@ load_dotenv()
 from flask import Flask, redirect, url_for, current_app, jsonify
 from flask_socketio import SocketIO
 
-from core.core_imports import log, configure_console_log, DB_PATH, BASE_DIR, retry_on_locked
+from core.core_imports import log, configure_console_log, BASE_DIR, retry_on_locked
+from core.constants import DB_PATH
 from data.data_locker import DataLocker
 from system.system_core import SystemCore
 from dashboard.dashboard_service import get_profit_badge_value

--- a/wallets/wallet_repository.py
+++ b/wallets/wallet_repository.py
@@ -15,7 +15,7 @@ from wallets.wallet_schema import WalletIn
 WALLETS_JSON_PATH = "wallets.json"
 
 from data.data_locker import DataLocker
-from core.core_imports import DB_PATH
+from core.constants import DB_PATH
 
 class WalletRepository:
     def __init__(self):


### PR DESCRIPTION
## Summary
- allow overriding DB_PATH via environment variable in `core/constants`
- drop redundant DB_PATH definition from `core/core_imports`
- update imports across the project to reference `DB_PATH` from `core.constants`
- clarify README instructions on setting `DB_PATH` for database initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*