### PR TITLE
Allow injecting MonitorRegistry into MonitorCore

### DIFF
--- a/FULL_SPEC.md
+++ b/FULL_SPEC.md
@@ -1290,7 +1290,7 @@ monitor/
 Central controller for executing registered monitors.
 
 ```python
-MonitorCore(registry: Optional[MonitorRegistry] = None)
+MonitorCore(registry: MonitorRegistry | None = None)
 ```
 - If `registry` is not provided, a new one is created and default monitors are registered (`PriceMonitor`, `PositionMonitor`, `OperationsMonitor`).
 

--- a/monitor/monitor_api.py
+++ b/monitor/monitor_api.py
@@ -18,7 +18,7 @@ registry.register("operations_monitor", OperationsMonitor())
 registry.register("position_monitor", PositionMonitor())
 registry.register("latency_monitor", LatencyMonitor())
 
-core = MonitorCore(registry)
+core = MonitorCore(registry=registry)
 
 @app.route("/monitors", methods=["GET"])
 def list_monitors():

--- a/monitor/monitor_console.py
+++ b/monitor/monitor_console.py
@@ -36,7 +36,7 @@ registry.register("operations_monitor", OperationsMonitor())
 registry.register("latency_monitor", LatencyMonitor())
 registry.register("position_monitor", PositionMonitor())
 
-core = MonitorCore(registry)
+core = MonitorCore(registry=registry)
 
 # ───────────────────────────────────────────────
 

--- a/monitor/monitor_core.py
+++ b/monitor/monitor_core.py
@@ -14,18 +14,27 @@ from monitor.twilio_monitor import TwilioMonitor
 from monitor.monitor_registry import MonitorRegistry
 
 class MonitorCore:
-    """
-    Central controller for all registered monitors.
-    """
-    def __init__(self):
-        self.registry = MonitorRegistry()
-        # Register all monitors here (ONLY place this ever happens)
-        self.registry.register("price_monitor", PriceMonitor())
-        self.registry.register("position_monitor", PositionMonitor())
-        self.registry.register("operations_monitor", OperationsMonitor())
-        self.registry.register("xcom_monitor", XComMonitor())
-        self.registry.register("twilio_monitor", TwilioMonitor())
-        # Add more monitors as needed
+    """Central controller for all registered monitors."""
+
+    def __init__(self, registry: MonitorRegistry | None = None):
+        """Create the core controller.
+
+        If ``registry`` is not supplied a new :class:`MonitorRegistry` instance
+        is created and the default monitors are registered. When a registry is
+        provided it is used as-is, allowing external callers to customize the
+        available monitors.
+        """
+
+        self.registry = registry or MonitorRegistry()
+
+        if registry is None:
+            # Register default monitors when no custom registry is supplied
+            self.registry.register("price_monitor", PriceMonitor())
+            self.registry.register("position_monitor", PositionMonitor())
+            self.registry.register("operations_monitor", OperationsMonitor())
+            self.registry.register("xcom_monitor", XComMonitor())
+            self.registry.register("twilio_monitor", TwilioMonitor())
+            # Add more monitors as needed
 
     def run_all(self):
         """

--- a/monitor/monitor_module_spec.md
+++ b/monitor/monitor_module_spec.md
@@ -26,7 +26,7 @@ monitor/
 Central controller for executing registered monitors.
 
 ```python
-MonitorCore(registry: Optional[MonitorRegistry] = None)
+MonitorCore(registry: MonitorRegistry | None = None)
 ```
 - If `registry` is not provided, a new one is created and default monitors are registered (`PriceMonitor`, `PositionMonitor`, `OperationsMonitor`).
 

--- a/operations_console.py
+++ b/operations_console.py
@@ -26,7 +26,7 @@ sysman = dl.system
 # Monitor Registration
 registry = MonitorRegistry()
 registry.register("price_monitor", PriceMonitor())
-monitor_core = MonitorCore(registry)
+monitor_core = MonitorCore(registry=registry)
 
 # ───────────────────────────────────────────────
 def clear_screen(): os.system("cls" if os.name == "nt" else "clear")


### PR DESCRIPTION
## Summary
- make `MonitorCore` accept an optional registry and register defaults only when none is provided
- update callers in monitor API, monitor console and operations console
- document new parameter in `monitor_module_spec.md`
- sync FULL_SPEC wording

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*