### PR TITLE
Fix logger import

### DIFF
--- a/monitor/monitor_console.py
+++ b/monitor/monitor_console.py
@@ -16,9 +16,6 @@ from operations_monitor import OperationsMonitor
 from latency_monitor import LatencyMonitor
 from position_monitor import PositionMonitor
 from core.logging import log
-
-
-from utils.console_logger import ConsoleLogger as log
 from core.core_imports import configure_console_log
 
 from data.data_locker import DataLocker

--- a/operations_console.py
+++ b/operations_console.py
@@ -5,8 +5,6 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 
 from core.logging import log
-
-from utils.console_logger import ConsoleLogger as log
 from core.core_imports import configure_console_log, DB_PATH
 
 from data.data_locker import DataLocker


### PR DESCRIPTION
## Summary
- use the RichLogger instance from `core.logging`
- drop the `ConsoleLogger` import

## Testing
- `python monitor/monitor_console.py` *(fails: ModuleNotFoundError: No module named 'rich')*
- `pytest -q` *(fails: ImportError while importing alert modules)*