### PR TITLE
Clean unused imports in operations_monitor

### DIFF
--- a/monitor/operations_monitor.py
+++ b/monitor/operations_monitor.py
@@ -6,8 +6,6 @@ sys.path.insert(0, PROJECT_ROOT)
 from datetime import datetime, timezone
 import logging
 import subprocess
-import threading
-import time
 
 from monitor.base_monitor import BaseMonitor
 from data.data_locker import DataLocker


### PR DESCRIPTION
## Summary
- remove unused `threading` and `time` imports from `operations_monitor.py`

## Testing
- `python -m py_compile monitor/operations_monitor.py`