### PR TITLE
Improve alert creation tests

### DIFF
--- a/tests/test_alert_core_create_all.py
+++ b/tests/test_alert_core_create_all.py
@@ -1,0 +1,19 @@
+import pytest
+
+from data.data_locker import DataLocker
+from alert_core.alert_core import AlertCore
+
+
+@pytest.mark.asyncio
+async def test_create_all_alerts_raises_typeerror(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+
+    dl = DataLocker(str(tmp_path / "core.db"))
+    core = AlertCore(dl)
+
+    with pytest.raises(TypeError):
+        await core.create_all_alerts()
+
+    dl.db.close()


### PR DESCRIPTION
## Summary
- add DataLocker to alert API tests so alerts persist to SQLite
- assert on database state after create/delete
- add async test for AlertCore.create_all_alerts TypeError bug

## Testing
- `pytest tests/test_alert_core_create_all.py -q` *(fails: ModuleNotFoundError: rapidfuzz)*
- `pytest tests/test_alerts_api.py::test_create_all_alerts -q` *(fails: ModuleNotFoundError: flask)*