### PR TITLE
Switch to TestCore for LaunchPad testing

### DIFF
--- a/launch_pad.py
+++ b/launch_pad.py
@@ -11,10 +11,10 @@ import time
 from datetime import datetime
 from functools import wraps
 from time import time as timer_time
-#from tests.test_runner_manager import TestRunnerManager
 from utils.schema_validation_service import SchemaValidationService
 from tests.verification_console import VerificationConsole
 from core.core_imports import log
+from test_core import TestCore
 
 
 
@@ -163,8 +163,11 @@ def run_operations_monitor():
 @timed_operation
 def run_test_manager():
     """Run the Test Runner Manager (interactive menu)."""
-    runner = TestRunnerManager(tests_folder="tests/")
-    runner.interactive_menu()
+    runner = TestCore()
+    if hasattr(runner, "interactive_menu"):
+        runner.interactive_menu()
+    else:
+        runner.run_all()
 
 def show_launchpad_banner():
     print("\n" + "=" * 60)

--- a/test_core/test_core.py
+++ b/test_core/test_core.py
@@ -72,3 +72,23 @@ class TestCore:
         except Exception:
             pass
 
+    # ------------------------------------------------------------------
+    def interactive_menu(self) -> None:
+        """Interactive CLI for running tests."""
+        print("\n=== 🔍 Test Runner Console ===")
+        print("1) Run all tests")
+        print("2) Run test file pattern")
+        print("3) Exit")
+
+        while True:
+            choice = input("Enter your choice (1-3): ").strip()
+            if choice == "1":
+                self.run_glob()
+            elif choice == "2":
+                pattern = input("Pattern (e.g., tests/test_*.py): ").strip()
+                self.run_glob(pattern)
+            elif choice == "3":
+                break
+            else:
+                print("Invalid choice. Try again.")
+


### PR DESCRIPTION
## Summary
- import `TestCore` for test running
- add an `interactive_menu` helper to `TestCore`
- run this new menu from LaunchPad instead of `TestRunnerManager`

## Testing
- `python -m py_compile launch_pad.py test_core/test_core.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz', etc.)*