### PR TITLE
Switch to TestCore in verification console

### DIFF
--- a/launch_pad.py
+++ b/launch_pad.py
@@ -11,7 +11,7 @@ import time
 from datetime import datetime
 from functools import wraps
 from time import time as timer_time
-#from tests.test_runner_manager import TestRunnerManager
+from test_core import TestCore
 from utils.schema_validation_service import SchemaValidationService
 from tests.verification_console import VerificationConsole
 from core.core_imports import log
@@ -162,9 +162,27 @@ def run_operations_monitor():
 
 @timed_operation
 def run_test_manager():
-    """Run the Test Runner Manager (interactive menu)."""
-    runner = TestRunnerManager(tests_folder="tests/")
-    runner.interactive_menu()
+    """Simple interactive test runner using :class:`TestCore`."""
+    core = TestCore()
+    while True:
+        print("\n=== 🔍 Test Runner Console ===")
+        print("1) Run all tests")
+        print("2) Run test file pattern")
+        print("3) Exit")
+
+        choice = input("Enter your choice (1-3): ").strip()
+        if choice == "1":
+            core.run_all()
+        elif choice == "2":
+            pattern = input("Pattern (e.g., tests/test_*.py): ").strip()
+            core.run_glob(pattern)
+        elif choice == "3":
+            break
+        else:
+            print("Invalid choice. Try again.")
+
+    input("\nPress ENTER to return to menu...")
+    clear_screen()
 
 def show_launchpad_banner():
     print("\n" + "=" * 60)

--- a/tests/verification_console.py
+++ b/tests/verification_console.py
@@ -3,13 +3,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 from pathlib import Path
 import webbrowser
-from tests.verification_manager import TestRunnerManager
+from test_core import TestCore
 from core.core_imports import log
 
 
 class VerificationConsole:
     def __init__(self):
-        self.runner = TestRunnerManager()
+        self.core = TestCore()
         self.report_dir = Path("reports")
         self.report_html = self.report_dir / "last_test_report.html"
         self.report_log = self.report_dir / "last_test_log.txt"
@@ -27,19 +27,19 @@ class VerificationConsole:
             choice = input("Enter your choice: ").strip()
 
             if choice == "1":
-                self.runner.run_tests_glob()
+                self.core.run_all()
 
             elif choice == "2":
                 file = input("📄 Enter file name (e.g. test_alerts.py): ").strip()
                 fpath = Path("tests") / file
                 if fpath.exists():
-                    self.runner.run_tests([fpath])
+                    self.core.run_files([fpath])
                 else:
                     log.error(f"❌ File not found: {fpath}", source="VerificationConsole")
 
             elif choice == "3":
                 pattern = input("🧬 Enter glob (e.g. tests/test_eval*.py): ").strip()
-                self.runner.run_tests_glob(pattern)
+                self.core.run_glob(pattern)
 
             elif choice == "4":
                 if self.report_html.exists():


### PR DESCRIPTION
## Summary
- use `TestCore` in verification console
- update launchpad test manager to rely on `TestCore`

## Testing
- `pytest -q` *(fails: 44 errors during collection)*