### PR TITLE
Update hedge labs ratio display

### DIFF
--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -98,11 +98,16 @@ def hedge_labs_page():
                 asset_img = ASSET_IMAGE_MAP.get(asset_key, DEFAULT_ASSET_IMAGE)
                 wallet_name = ref_pos.get("wallet_name") or ref_pos.get("wallet")
                 wallet_img = WALLET_IMAGE_MAP.get(wallet_name, DEFAULT_WALLET_IMAGE)
+        total_size = abs(h.total_long_size) + abs(h.total_short_size)
+        long_ratio = int(round(abs(h.total_long_size) / total_size * 100)) if total_size else 0
+        short_ratio = int(round(abs(h.total_short_size) / total_size * 100)) if total_size else 0
         return {
             "id": h.id,
             "positions": h.positions,
             "total_long_size": h.total_long_size,
             "total_short_size": h.total_short_size,
+            "long_size_ratio": long_ratio,
+            "short_size_ratio": short_ratio,
             "long_heat_index": h.long_heat_index,
             "short_heat_index": h.short_heat_index,
             "total_heat_index": h.total_heat_index,
@@ -156,11 +161,16 @@ def api_get_hedges():
                 asset_img = ASSET_IMAGE_MAP.get(asset_key, DEFAULT_ASSET_IMAGE)
                 wallet_name = ref_pos.get("wallet_name") or ref_pos.get("wallet")
                 wallet_img = WALLET_IMAGE_MAP.get(wallet_name, DEFAULT_WALLET_IMAGE)
+        total_size = abs(h.total_long_size) + abs(h.total_short_size)
+        long_ratio = int(round(abs(h.total_long_size) / total_size * 100)) if total_size else 0
+        short_ratio = int(round(abs(h.total_short_size) / total_size * 100)) if total_size else 0
         return {
             "id": h.id,
             "positions": h.positions,
             "total_long_size": h.total_long_size,
             "total_short_size": h.total_short_size,
+            "long_size_ratio": long_ratio,
+            "short_size_ratio": short_ratio,
             "total_heat_index": h.total_heat_index,
             "long_leverage": float(long_pos.get("leverage", 0.0)) if long_pos else 0.0,
             "short_leverage": float(short_pos.get("leverage", 0.0)) if short_pos else 0.0,

--- a/static/js/hedge_labs.js
+++ b/static/js/hedge_labs.js
@@ -9,7 +9,7 @@ function loadHedges() {
           const tr = document.createElement('tr');
           const assetImg = `/static/images/${h.asset_image}`;
           const walletImg = `/static/images/${h.wallet_image}`;
-          const info = `Total Value = ${h.total_value} Size (${h.total_long_size}/${h.total_short_size}), Leverage (${h.long_leverage}/${h.short_leverage})`;
+          const info = `Total Value = ${h.total_value} Ratio (${h.long_size_ratio}%, ${h.short_size_ratio}%), Leverage (${h.long_leverage}/${h.short_leverage})`;
           tr.innerHTML = `
             <td>
               <img class="asset-icon me-1" src="${assetImg}" alt="asset">

--- a/templates/hedge_labs.html
+++ b/templates/hedge_labs.html
@@ -44,7 +44,7 @@
             <span class="mx-1">⛓️</span>
             <img class="wallet-icon ms-1" src="{{ url_for('static', filename='images/' + h.wallet_image) }}" alt="wallet">
           </td>
-          <td>Tot&nbsp;Value&nbsp;=&nbsp;{{ h.total_value }} Size ({{ h.total_long_size }}/{{ h.total_short_size }}), Leverage ({{ h.long_leverage }}/{{ h.short_leverage }})</td>
+          <td>Tot&nbsp;Value&nbsp;=&nbsp;{{ h.total_value }} Ratio ({{ h.long_size_ratio }}%, {{ h.short_size_ratio }}%), Leverage ({{ h.long_leverage }}/{{ h.short_leverage }})</td>
           <td>{{ h.total_heat_index }}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- compute long/short ratio for hedges
- show ratio instead of raw sizes in Hedge Labs UI

## Testing
- `pytest -q` *(fails: 42 errors during collection)*