### PR TITLE
Simplify operations monitor startup logging

### DIFF
--- a/launch_pad.py
+++ b/launch_pad.py
@@ -54,7 +54,7 @@ def operations_menu():
         choice = input("→ ").strip().lower()
         if choice == "1":
             monitor = OperationsMonitor()
-            result = monitor.run_startup_configuration_test()
+            result = monitor.run_configuration_test()
             log.info("Config Test Result", payload=result)
             input("Press ENTER to continue...")
         elif choice == "b":

--- a/tests/test_operations_monitor.py
+++ b/tests/test_operations_monitor.py
@@ -17,17 +17,17 @@ def patch_datalocker(monkeypatch):
     monkeypatch.setattr(om, "DataLocker", DummyLocker)
 
 
-def test_run_startup_configuration_test_missing_file(tmp_path, monkeypatch):
+def test_run_configuration_test_missing_file(tmp_path, monkeypatch):
     missing = tmp_path / "missing.json"
     monkeypatch.setattr(om, "ALERT_LIMITS_PATH", missing)
     monkeypatch.setattr(SchemaValidationService, "ALERT_LIMITS_FILE", str(missing))
 
     monitor = om.OperationsMonitor()
-    result = monitor.run_startup_configuration_test()
+    result = monitor.run_configuration_test()
     assert result["config_success"] is False
 
 
-def test_run_startup_configuration_test_valid_file(tmp_path, monkeypatch):
+def test_run_configuration_test_valid_file(tmp_path, monkeypatch):
     valid_file = tmp_path / "alert_limits.json"
     valid_data = {
         "alert_ranges": {
@@ -51,5 +51,5 @@ def test_run_startup_configuration_test_valid_file(tmp_path, monkeypatch):
     monkeypatch.setattr(SchemaValidationService, "ALERT_LIMITS_FILE", str(valid_file))
 
     monitor = om.OperationsMonitor()
-    result = monitor.run_startup_configuration_test()
+    result = monitor.run_configuration_test()
     assert result["config_success"] is True


### PR DESCRIPTION
## Summary
- rename `run_startup_configuration_test` to `run_configuration_test`
- run configuration check inside `run_startup_post`
- add threaded spinner and summary stats for POST tests
- adjust launch pad and tests for the new method

## Testing
- `pytest -q tests/test_operations_monitor.py`
- `pytest -q` *(fails: 42 errors during collection)*