### PR TITLE
Fix circular import in core package

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -8,4 +8,22 @@ from core.logging import log, configure_console_log
 from core.locker_factory import get_locker
 from core.constants import DB_PATH, CONFIG_PATH, BASE_DIR
 from utils.db_retry import retry_on_locked
-from utils.json_manager import JsonManager
+__all__ = [
+    "log",
+    "configure_console_log",
+    "get_locker",
+    "DB_PATH",
+    "CONFIG_PATH",
+    "BASE_DIR",
+    "retry_on_locked",
+    "JsonManager",
+]
+
+
+def __getattr__(name):
+    """Lazily import optional utilities to avoid circular imports."""
+    if name == "JsonManager":
+        from utils.json_manager import JsonManager
+
+        return JsonManager
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- avoid circular import loading `JsonManager`

## Testing
- `pytest -q` *(fails: 42 errors during collection)*