### PR TITLE
Fix pytest plugin loading

### DIFF
--- a/test_core/test_core.py
+++ b/test_core/test_core.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import sys
 import contextlib
+import os
+import importlib
 from pathlib import Path
 import pytest
 from core.core_imports import log
@@ -38,15 +40,25 @@ class TestCore:
         log.banner(f"🧪 Test Run Started ({len(files)} file(s))")
         log.info(f"⏱ Running: {[str(f) for f in files]}", source="TestCore")
 
-        args = [
-            *[str(f) for f in files],
-            "-q", "--tb=short",
-            "-p", "pytest_sugar",
-            "-p", "pytest_spec",
-            "-p", "pytest_console_scripts",
+        args = [*[str(f) for f in files], "-q", "--tb=short"]
+
+        # Include optional plugins only if they are installed. This avoids
+        # ``pytest`` failing when a plugin is referenced but not available in
+        # the environment.
+        for plugin in ["pytest_sugar", "pytest_spec", "pytest_console_scripts"]:
+            if importlib.util.find_spec(plugin) is not None:
+                args.extend(["-p", plugin])
+
+        args.extend([
             f"--html={html_report}", "--self-contained-html",
             "--json-report", f"--json-report-file={json_report}",
-        ]
+        ])
+
+        # Prevent auto-loading of external plugins which may introduce
+        # unwanted dependencies (e.g. anchorpy's pytest plugin requiring
+        # ``pytest_xprocess``).  Only the explicitly specified plugins
+        # should be loaded during the test run.
+        os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
 
         with open(txt_log, "w", encoding="utf-8") as f, \
              contextlib.redirect_stdout(f), contextlib.redirect_stderr(f):


### PR DESCRIPTION
## Summary
- stop pytest from loading unexpected third‑party plugins
- only enable optional pytest plugins when installed

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: ModuleNotFoundError: rapidfuzz)*