### PR TITLE
Fix plugin options

### DIFF
--- a/test_core/test_core.py
+++ b/test_core/test_core.py
@@ -65,10 +65,6 @@ class TestCore:
                 f"--json-report-file={json_report}",
             ])
 
-        args.extend([
-            f"--html={html_report}", "--self-contained-html",
-            "--json-report", f"--json-report-file={json_report}",
-        ])
 
 
         # Prevent auto-loading of external plugins which may introduce


### PR DESCRIPTION
## Summary
- remove unconditional pytest report options

## Testing
- `python -m test_core.test_core` *(fails: ModuleNotFoundError: No module named 'rich')*