### PR TITLE
Fix test imports

### DIFF
--- a/alert_core/tests/test_alert_core.py
+++ b/alert_core/tests/test_alert_core.py
@@ -7,6 +7,9 @@ from datetime import datetime
 # Ensure repo root is on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
+import pytest
+from alert_core.TESTER import run_test
+
 from data.data_locker import DataLocker
 from alert_core.alert_core import AlertCore
 from data.alert import AlertType, Condition


### PR DESCRIPTION
## Summary
- ensure repo root is on path before importing from alert_core modules in tests
- import pytest and run_test helper for alert_core tests

## Testing
- `pytest alert_core/tests/test_alert_core.py::test_alert_core_basic -q`
- `pytest alert_core/tests/test_alert_core_barrage.py::test_alert_core_barrage -q`
