### PR TITLE
Graceful fallback when database unavailable

### DIFF
--- a/data/dl_monitor_ledger.py
+++ b/data/dl_monitor_ledger.py
@@ -15,6 +15,9 @@ class DLMonitorLedgerManager:
 
     def ensure_table(self):
         cursor = self.db.get_cursor()
+        if not cursor:
+            log.error("❌ DB unavailable, ledger table not created", source="DLMonitorLedger")
+            return
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS monitor_ledger (
                 id TEXT PRIMARY KEY,
@@ -42,6 +45,9 @@ class DLMonitorLedgerManager:
 
 
         cursor = self.db.get_cursor()
+        if not cursor:
+            log.error("❌ DB unavailable, ledger entry not stored", source="DLMonitorLedger")
+            return
         cursor.execute("""
             INSERT INTO monitor_ledger (
                 id, monitor_name, timestamp, status, metadata
@@ -54,6 +60,9 @@ class DLMonitorLedgerManager:
 
     def get_last_entry(self, monitor_name: str) -> dict:
         cursor = self.db.get_cursor()
+        if not cursor:
+            log.error("❌ DB unavailable, cannot fetch ledger entry", source="DLMonitorLedger")
+            return {}
         cursor.execute("""
             SELECT timestamp, status, metadata
             FROM monitor_ledger

--- a/tests/test_invalid_data_locker.py
+++ b/tests/test_invalid_data_locker.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+from data.data_locker import DataLocker
+
+
+def test_data_locker_handles_invalid_path(monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+
+    path = "/dev/null/test.db"  # invalid directory
+    try:
+        dl = DataLocker(path)
+    except Exception as e:
+        pytest.fail(f"DataLocker raised an exception: {e}")
+
+    assert dl.get_all_tables_as_dict() == {}
+    dl.db.close()


### PR DESCRIPTION
## Summary
- avoid raising from DatabaseManager
- handle cursor/commit failures in DataLocker and managers
- ensure ledger manager and position manager check for missing DB
- add regression test for invalid DB path

## Testing
- `pytest tests/test_invalid_data_locker.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'solana')*