### PR TITLE
Fix run_glob path filtering

### DIFF
--- a/test_core/test_core.py
+++ b/test_core/test_core.py
@@ -25,7 +25,12 @@ class TestCore:
     def run_glob(self, pattern: str | None = None) -> None:
         """Discover test files matching *pattern* and run them."""
         pattern = pattern or self.default_pattern
-        files = [p for p in Path(".").rglob(pattern)]
+        files = [
+            p
+            for p in Path(".").rglob(pattern)
+            # Exclude common virtual environment directories
+            if not any(part in {".venv", "venv", "site-packages"} for part in p.parts)
+        ]
         if not files:
             log.warning(f"⚠️ No test files found for pattern: {pattern}", source="TestCore")
             return

--- a/tests/test_run_glob.py
+++ b/tests/test_run_glob.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from test_core.test_core import TestCore
+
+
+def test_run_glob_filters_virtual_envs(tmp_path, monkeypatch):
+    # Set up directory structure with various test files
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "test_valid.py").write_text("")
+
+    for d in [".venv", "venv", "site-packages"]:
+        (tmp_path / d).mkdir()
+        (tmp_path / d / "test_ignore.py").write_text("")
+
+    captured: list[Path] = []
+
+    def fake_run_files(self, files):
+        captured.extend(files)
+
+    tc = TestCore()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(TestCore, "run_files", fake_run_files)
+
+    tc.run_glob("test_*.py")
+
+    assert captured == [Path("sub/test_valid.py")]


### PR DESCRIPTION
## Summary
- exclude `.venv`, `venv`, and `site-packages` directories when discovering tests
- test that run_glob ignores virtual environment directories

## Testing
- `pytest tests/test_run_glob.py -q`