### PR TITLE
Fix tests infrastructure, add alert service

### DIFF
--- a/alert_core/__init__.py
+++ b/alert_core/__init__.py
@@ -1,1 +1,11 @@
+"""Minimal alert_core package exports for the tests."""
 
+from .alert_repository import AlertRepository
+from .alert_service import AlertService
+from .alert_core import AlertCore
+
+__all__ = [
+    "AlertRepository",
+    "AlertService",
+    "AlertCore",
+]

--- a/alert_core/alert_repository.py
+++ b/alert_core/alert_repository.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from data.alert import Alert
+
+
+class AlertRepository:
+    """Lightweight repository wrapping a data locker-like backend."""
+
+    def __init__(self, data_locker):
+        self.data_locker = data_locker
+
+    def create_alert(self, alert_data: dict):
+        if "starting_value" not in alert_data:
+            getter = getattr(self.data_locker, "get_current_value", None)
+            if callable(getter):
+                alert_data["starting_value"] = getter(alert_data.get("asset"))
+
+        if hasattr(self.data_locker, "create_alert"):
+            return self.data_locker.create_alert(alert_data)
+        if hasattr(self.data_locker, "alerts") and hasattr(self.data_locker.alerts, "create_alert"):
+            return self.data_locker.alerts.create_alert(alert_data)
+        if hasattr(self.data_locker, "alerts") and isinstance(self.data_locker.alerts, list):
+            self.data_locker.alerts.append(Alert(**alert_data))
+            return alert_data
+        raise AttributeError("DataLocker does not support alert creation")
+
+    async def get_active_alerts(self) -> list[Alert]:
+        if hasattr(self.data_locker, "get_alerts"):
+            raw = self.data_locker.get_alerts()
+        elif hasattr(self.data_locker, "alerts") and hasattr(self.data_locker.alerts, "get_all_alerts"):
+            raw = self.data_locker.alerts.get_all_alerts()
+        elif hasattr(self.data_locker, "alerts"):
+            raw = self.data_locker.alerts
+        else:
+            raw = []
+        alerts = []
+        for a in raw:
+            if isinstance(a, Alert):
+                alerts.append(a)
+            elif isinstance(a, dict):
+                alerts.append(Alert(**a))
+        return alerts
+
+    async def update_alert_level(self, alert_id: str, level):
+        update = {"level": level}
+        self._update(alert_id, update)
+
+    async def update_alert_evaluated_value(self, alert_id: str, value: float):
+        update = {"evaluated_value": value}
+        self._update(alert_id, update)
+
+    # ------------------------------------------------------------------
+    def _update(self, alert_id: str, fields: dict) -> None:
+        if hasattr(self.data_locker, "update_alert_conditions"):
+            self.data_locker.update_alert_conditions(alert_id, fields)
+        elif hasattr(self.data_locker, "alerts") and hasattr(self.data_locker.alerts, "update_alert_conditions"):
+            self.data_locker.alerts.update_alert_conditions(alert_id, fields)
+        elif hasattr(self.data_locker, "alerts") and isinstance(self.data_locker.alerts, list):
+            for a in self.data_locker.alerts:
+                if getattr(a, "id", None) == alert_id:
+                    for k, v in fields.items():
+                        setattr(a, k, v)
+                    break

--- a/alert_core/alert_service.py
+++ b/alert_core/alert_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import inspect
+
+from xcom.notification_service import NotificationService
+from data.alert import Alert
+from core.logging import log
+
+
+class AlertService:
+    """High level coordinator for alert processing."""
+
+    def __init__(self, repository, enrichment_service, config_loader=None):
+        self.repository = repository
+        self.enrichment_service = enrichment_service
+        self.config_loader = config_loader or (lambda: {})
+        self.notification_service = NotificationService(self.config_loader)
+
+    async def process_all_alerts(self) -> None:
+        alerts = await self.repository.get_active_alerts()
+        for alert in alerts:
+            enriched = await self.enrichment_service.enrich(alert)
+            await self.repository.update_alert_evaluated_value(
+                enriched.id, getattr(enriched, "evaluated_value", None)
+            )
+            await self.repository.update_alert_level(
+                enriched.id, getattr(enriched, "level", None)
+            )
+            try:
+                await self.notification_service.send_alert(enriched)
+            except Exception as e:  # pragma: no cover - notification best effort
+                log.error(f"Notification failed for {enriched.id}: {e}", source="AlertService")

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+import asyncio
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "asyncio: mark test as async")
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem):
+    """Run async test functions in the event loop."""
+    if asyncio.iscoroutinefunction(pyfuncitem.obj):
+        loop = pyfuncitem.funcargs.get("event_loop")
+        loop.run_until_complete(pyfuncitem.obj(**pyfuncitem.funcargs))
+        return True

--- a/cyclone/cyclone_engine.py
+++ b/cyclone/cyclone_engine.py
@@ -66,11 +66,13 @@ def configure_cyclone_console_log():
 
 
 class Cyclone:
-    def __init__(self, monitor_core, poll_interval=60):
+    def __init__(self, monitor_core: MonitorCore | None = None, poll_interval: int = 60):
         self.logger = logging.getLogger("Cyclone")
         self.poll_interval = poll_interval
         self.logger.setLevel(logging.DEBUG)
-        self.monitor_core = monitor_core
+        # Allow tests and scripts to instantiate ``Cyclone`` without explicitly
+        # providing a ``MonitorCore`` instance.
+        self.monitor_core = monitor_core or MonitorCore()
 
         self.data_locker = global_data_locker
         self.price_sync = PriceSyncService(self.data_locker)
@@ -95,7 +97,6 @@ class Cyclone:
             self.data_locker,
             config_loader=lambda: self.config,
         )
-        self.monitor_core = monitor_core
         self.wallet_service = CycloneWalletService(self.data_locker)
         self.maintenance_service = CycloneMaintenanceService(self.data_locker)
         self.hedge_core = HedgeCore(self.data_locker)
@@ -234,20 +235,6 @@ class Cyclone:
         await self.alert_core.update_evaluated_values()
         log.success("✅ Evaluated alert values updated", source="Cyclone")
 
-    def clear_prices_backend(self):
-        self.sys.clear_prices()
-
-    def clear_wallets_backend(self):
-        self.sys.clear_wallets()
-
-    def clear_alerts_backend(self):
-        self.sys.clear_alerts()
-
-    def clear_positions_backend(self):
-        self.sys.clear_positions()
-
-    def _clear_all_data_core(self):
-        self.sys.clear_all_tables()
 
     # ⚙️ Corrected clear helpers
     def clear_prices_backend(self):

--- a/cyclone/tests/test_cyclone_step_create_position_alerts.py
+++ b/cyclone/tests/test_cyclone_step_create_position_alerts.py
@@ -6,7 +6,7 @@ import asyncio
 import random
 
 from datetime import datetime
-#from data.data_locker import DataLocker
+from data.data_locker import DataLocker
 from core.constants import DB_PATH
 from data.alert import AlertType, Condition
 from cyclone.cyclone_engine import Cyclone

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 asyncio_mode = auto
+markers =
+    asyncio: mark test as async

--- a/test_core/test_core.py
+++ b/test_core/test_core.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 import contextlib
 import os
+# Disable auto loading of external pytest plugins **before** importing pytest.
+os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
 import importlib
 from pathlib import Path
 import pytest
@@ -11,6 +13,9 @@ from core.core_imports import log
 
 class TestCore:
     """Utility to run pytest with rich reporting."""
+
+    # Prevent ``pytest`` from collecting this class as a test case.
+    __test__ = False
 
     def __init__(self, report_dir: str | Path = "reports", default_pattern: str = "tests/test_*.py") -> None:
         self.report_dir = Path(report_dir)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -26,3 +26,4 @@ markers =
     system: mark a test as a system integration test
     unit: mark a test as a unit test
     slow: mark a test as slow (optional)
+    asyncio: mark test as async

--- a/tests/test_big_alert_flow.py
+++ b/tests/test_big_alert_flow.py
@@ -26,8 +26,8 @@ class MockDataLocker:
                     setattr(a, key, val)
 
     def get_current_timestamp(self):
-from datetime import datetime
-from core.core_imports import log
+        from datetime import datetime
+        from core.core_imports import log
         return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 @pytest.mark.asyncio

--- a/tests/test_price_threshold_alert.py
+++ b/tests/test_price_threshold_alert.py
@@ -55,8 +55,8 @@ class MockDataLockerProfit:
                     a.last_triggered = fields['last_triggered']
 
     def get_current_timestamp(self):
-from datetime import datetime
-from core.core_imports import log
+        from datetime import datetime
+        from core.core_imports import log
         return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 

--- a/tests/test_travel_percent_alert.py
+++ b/tests/test_travel_percent_alert.py
@@ -49,8 +49,8 @@ class MockDataLockerTravelPercent:
                     setattr(a, key, val)
 
     def get_current_timestamp(self):
-from datetime import datetime
-from core.core_imports import log
+        from datetime import datetime
+        from core.core_imports import log
         return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 # --- Test Case ---

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -1,0 +1,3 @@
+from config.config_loader import load_config, update_config
+
+__all__ = ["load_config", "update_config"]

--- a/xcom/__init__.py
+++ b/xcom/__init__.py
@@ -1,1 +1,5 @@
+"""Minimal xcom package exports used in tests."""
 
+from .notification_service import NotificationService
+
+__all__ = ["NotificationService"]

--- a/xcom/notification_service.py
+++ b/xcom/notification_service.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+class NotificationService:
+    """Very small stub used for tests."""
+
+    def __init__(self, config_loader=None):
+        self.config_loader = config_loader or (lambda: {})
+
+    async def send_alert(self, alert) -> bool:
+        """Pretend to dispatch an alert notification."""
+        return True


### PR DESCRIPTION
## Summary
- prevent pytest autoload and skip by default
- mark `TestCore` as non-test and disable plugin autoload early
- provide simple alert repository and service modules
- stub notification service in `xcom`
- patch Cyclone to allow optional monitor core
- fix indent issues in tests and enable async running via `conftest`
- expose new markers in pytest config
- add small config loader helper

## Testing
- `pytest tests/test_run_glob.py::test_run_glob_filters_virtual_envs tests/test_alert_starting_value.py::test_starting_value_injection -q`
