### PR TITLE
Fix table theme in wallet page

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -279,4 +279,24 @@ body.mobile-mode .sonic-section-container {
 .mini-table-box table {
   width: 100%;
   margin: 0 auto;
+  background: var(--container-bg);
+  color: var(--text);
+}
+
+.mini-table-box thead th {
+  background: var(--title-bar-bg);
+  color: var(--panel-title);
+  border-bottom: 2px solid var(--panel-border);
+  padding: 0.7em 0.6em;
+}
+
+.mini-table-box tbody td {
+  background: var(--container-bg);
+  color: var(--text);
+  border-bottom: 1px solid var(--panel-border);
+  padding: 0.7em 0.6em;
+}
+
+.mini-table-box table.table-striped > tbody > tr:nth-of-type(odd) > * {
+  background-color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- apply theme colors to wallet and blockchain tables so they respect sonic themes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'solana')*