### PR TITLE
Add alert management dropdown

### DIFF
--- a/cyclone/cyclone_bp.py
+++ b/cyclone/cyclone_bp.py
@@ -107,6 +107,27 @@ def clear_all_data():
         log.error(f"Clear All Data Error: {e}", source="CycloneAPI")
         return jsonify({"error": str(e)}), 500
 
+# --- Alert Management Endpoints ---
+@cyclone_bp.route("/run_create_alerts", methods=["POST"])
+def run_create_alerts():
+    try:
+        run_in_background(lambda: asyncio.run(current_app.cyclone.alert_core.create_all_alerts()),
+                          name="CreateAlerts")
+        return jsonify({"message": "Alert creation started."}), 202
+    except Exception as e:
+        log.error(f"Create Alerts Error: {e}", source="CycloneAPI")
+        return jsonify({"error": str(e)}), 500
+
+@cyclone_bp.route("/clear_alerts", methods=["POST"])
+def clear_alerts():
+    try:
+        run_in_background(current_app.cyclone.clear_alerts_backend,
+                          name="ClearAlerts")
+        return jsonify({"message": "Alert deletion started."}), 202
+    except Exception as e:
+        log.error(f"Clear Alerts Error: {e}", source="CycloneAPI")
+        return jsonify({"error": str(e)}), 500
+
 @cyclone_bp.route("/cyclone_logs", methods=["GET"])
 def api_cyclone_logs():
     try:

--- a/static/js/alert_status_actions.js
+++ b/static/js/alert_status_actions.js
@@ -1,0 +1,39 @@
+// alert_status_actions.js
+console.log('✅ alert_status_actions loaded');
+
+function callEndpoint(url, icon, label) {
+  if (typeof showToast === 'function') {
+    showToast(`${icon} ${label} started...`);
+  }
+  return fetch(url, { method: 'POST' })
+    .then(res => res.json())
+    .then(data => {
+      if (data.message) {
+        showToast(`${icon} ${label} complete: ${data.message}`);
+      } else if (data.error) {
+        showToast(`❌ ${label} failed: ${data.error}`, true);
+      } else {
+        showToast(`⚠️ ${label} returned unknown response`, true);
+      }
+    })
+    .catch(err => {
+      console.error(`${label} error:`, err);
+      showToast(`❌ ${label} failed to connect`, true);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const actions = {
+    add: () => callEndpoint('/cyclone/run_create_alerts', '➕', 'Add Alerts'),
+    delete: () => callEndpoint('/cyclone/clear_alerts', '🗑️', 'Delete Alerts'),
+    update: () => callEndpoint('/cyclone/run_alert_evaluations', '🔄', 'Update Alert State')
+  };
+
+  const addBtn = document.querySelector('.alert-add');
+  const delBtn = document.querySelector('.alert-delete');
+  const updBtn = document.querySelector('.alert-update');
+
+  if (addBtn) addBtn.addEventListener('click', (e) => { e.preventDefault(); actions.add(); });
+  if (delBtn) delBtn.addEventListener('click', (e) => { e.preventDefault(); actions.delete(); });
+  if (updBtn) updBtn.addEventListener('click', (e) => { e.preventDefault(); actions.update(); });
+});

--- a/static/js/api_routes.js
+++ b/static/js/api_routes.js
@@ -5,6 +5,9 @@ const CYCLONE_ROUTES = {
   positionUpdates: "/cyclone/run_position_updates",
   marketUpdates: "/cyclone/run_market_updates",
   fullCycle: "/cyclone/run_full_cycle",
-  clearAllData: "/cyclone/clear_all_data"
+  clearAllData: "/cyclone/clear_all_data",
+  createAlerts: "/cyclone/run_create_alerts",
+  clearAlerts: "/cyclone/clear_alerts",
+  updateAlerts: "/cyclone/run_alert_evaluations"
 };
 

--- a/templates/alert_status.html
+++ b/templates/alert_status.html
@@ -19,7 +19,19 @@
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel">
       <div class="alert-table">
-        <div class="section-title">Alerts</div>
+        <div class="section-title d-flex justify-content-between align-items-center">
+          <span>Alerts</span>
+          <div class="dropdown">
+            <a href="#" class="btn btn-light btn-sm dropdown-toggle" id="alertMenu" data-bs-toggle="dropdown" aria-expanded="false" title="Manage Alerts">
+              <i class="fas fa-ellipsis-v"></i>
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="alertMenu">
+              <li><a class="dropdown-item alert-add" href="#">Add Alerts</a></li>
+              <li><a class="dropdown-item alert-delete" href="#">Delete Alerts</a></li>
+              <li><a class="dropdown-item alert-update" href="#">Update Alert State</a></li>
+            </ul>
+          </div>
+        </div>
         {% set type_icons = {
           'pricethreshold': '💵',
           'deltachange': '📊',
@@ -204,4 +216,5 @@ document.addEventListener("DOMContentLoaded", function() {
 </script>
 <script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
 <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+<script src="{{ url_for('static', filename='js/alert_status_actions.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add alert management dropdown to alert status page
- create JS handlers for dropdown actions
- support new cyclone endpoints for alert management
- expose routes in api routes

## Testing
- `pytest -q` *(fails: 21 errors during collection)*