### PR TITLE
Enhance profit badge with funky animations

### DIFF
--- a/static/css/title_bar.css
+++ b/static/css/title_bar.css
@@ -243,8 +243,27 @@
 }
 
 .profit-badge {
-  font-size: 0.75rem;
+  font-size: 1rem;
   font-weight: 600;
+  padding: 0.4em 0.75em;
+  border-radius: 0.75rem;
+  animation: bounceIn 1.5s ease, float 3s ease-in-out infinite, pulseGlow 2s infinite;
+}
+
+@keyframes pulseGlow {
+  0%, 100% { box-shadow: 0 0 0 rgba(40, 167, 69, 0.4); }
+  50% { box-shadow: 0 0 15px rgba(40, 167, 69, 0.8); }
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-10px); }
+}
+
+@keyframes bounceIn {
+  0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-20px); }
+  60% { transform: translateY(-10px); }
 }
 
 


### PR DESCRIPTION
## Summary
- increase profit badge size
- add pulsing glow, floating and bounce animations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*