### PR TITLE
Add JSON import/export for alert thresholds

### DIFF
--- a/static/js/alert_thresholds.js
+++ b/static/js/alert_thresholds.js
@@ -1,12 +1,11 @@
 window.addEventListener('DOMContentLoaded', () => {
   const saveBtn = document.getElementById('saveAllThresholds');
-  if (!saveBtn) return;
+  const importBtn = document.getElementById('importThresholds');
+  const exportBtn = document.getElementById('exportThresholds');
 
-  saveBtn.addEventListener('click', async evt => {
-    evt.preventDefault();
-
+  function gatherPayload() {
     const rows = document.querySelectorAll('tr[data-id]');
-    const payload = Array.from(rows).map(row => ({
+    return Array.from(rows).map(row => ({
       id: row.dataset.id,
       low: parseFloat(row.querySelector('[name="low"]').value) || 0,
       medium: parseFloat(row.querySelector('[name="medium"]').value) || 0,
@@ -16,6 +15,11 @@ window.addEventListener('DOMContentLoaded', () => {
       medium_notify: Array.from(row.querySelectorAll('[name="medium_notify"]:checked')).map(el => el.value),
       high_notify: Array.from(row.querySelectorAll('[name="high_notify"]:checked')).map(el => el.value)
     }));
+  }
+
+  if (saveBtn) saveBtn.addEventListener('click', async evt => {
+    evt.preventDefault();
+    const payload = gatherPayload();
 
     try {
       const resp = await fetch('/system/alert_thresholds/update_all', {
@@ -39,5 +43,58 @@ window.addEventListener('DOMContentLoaded', () => {
         showToast('❌ Error saving thresholds', true);
       }
     }
+  });
+
+  if (exportBtn) exportBtn.addEventListener('click', async evt => {
+    evt.preventDefault();
+    try {
+      const resp = await fetch('/system/alert_thresholds/export');
+      const data = await resp.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'alert_thresholds.json';
+      a.click();
+      URL.revokeObjectURL(url);
+      if (typeof showToast === 'function') {
+        showToast('✅ Exported alert_thresholds.json');
+      }
+    } catch (err) {
+      if (typeof showToast === 'function') {
+        showToast('❌ Failed to export thresholds', true);
+      }
+    }
+  });
+
+  if (importBtn) importBtn.addEventListener('click', evt => {
+    evt.preventDefault();
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.addEventListener('change', async () => {
+      const file = input.files[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const payload = JSON.parse(text);
+        const resp = await fetch('/system/alert_thresholds/import', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+          showToast('✅ Thresholds imported');
+          location.reload();
+        } else {
+          const msg = data.error || resp.statusText;
+          showToast(`❌ Import failed: ${msg}`, true);
+        }
+      } catch (err) {
+        showToast('❌ Error importing thresholds', true);
+      }
+    });
+    input.click();
   });
 });

--- a/templates/system/alert_thresholds.html
+++ b/templates/system/alert_thresholds.html
@@ -15,6 +15,11 @@
 {% include "title_bar.html" %}
 <div class="container-fluid pt-4">
   <!-- Title moved to bar -->
+  <div class="d-flex justify-content-end mb-3 gap-2">
+    <button id="importThresholds" class="btn btn-secondary">Import</button>
+    <button id="exportThresholds" class="btn btn-secondary">Export</button>
+    <button id="saveAllThresholds" class="btn btn-primary">Save All</button>
+  </div>
   {% set type_icons = {
     'pricethreshold': '💵',
     'deltachange': '📊',
@@ -93,9 +98,6 @@
     </div>
   </div>
   {% endfor %}
-  <div class="text-end mb-3">
-    <button id="saveAllThresholds" class="btn btn-primary">Save All</button>
-  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- extend `DLThresholdManager` with JSON helpers
- support import/export of alert thresholds in `system_bp`
- add Import/Export buttons to template and JS logic
- move action buttons to top of page

## Testing
- `pytest -q` *(fails: 21 errors during collection)*