### PR TITLE
Fix theme toggle on dashboard

### DIFF
--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -28,47 +28,8 @@
 
   <!-- JS: Layout Mode Toggle -->
   <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
-  <!-- JS: Theme Toggle -->
-  <script>
-    const THEME_KEY = "themeMode";
-    function setTheme(mode) {
-      document.documentElement.setAttribute("data-theme", mode);
-      localStorage.setItem(THEME_KEY, mode);
-      document.cookie = THEME_KEY + "=" + mode + ";path=/;max-age=31536000";
-    }
-    function getPersistedTheme() {
-      let mode = localStorage.getItem(THEME_KEY);
-      if (!mode) {
-        const cookie = document.cookie.split('; ').find(r => r.startsWith(THEME_KEY + '='));
-        if (cookie) mode = cookie.split('=')[1];
-      }
-      return mode || "light";
-    }
-    function bindThemeButtons() {
-      const buttons = document.querySelectorAll('.theme-btn[data-theme]');
-      buttons.forEach(btn => {
-        btn.addEventListener('click', e => {
-          const mode = btn.getAttribute('data-theme');
-          setTheme(mode);
-          buttons.forEach(b => b.classList.remove('active'));
-          btn.classList.add('active');
-        });
-      });
-    }
-    document.addEventListener("DOMContentLoaded", () => {
-      const mode = getPersistedTheme();
-      setTheme(mode);
-      const buttons = document.querySelectorAll('.theme-btn[data-theme]');
-      buttons.forEach(btn => {
-        if (btn.getAttribute('data-theme') === mode) {
-          btn.classList.add('active');
-        } else {
-          btn.classList.remove('active');
-        }
-      });
-      bindThemeButtons();
-    });
-  </script>
+  <!-- Theme toggle logic is centralized in sonic_theme_toggle.js -->
+  <script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
   <!-- The title bar includes title_bar.js which already attaches
        click handlers to the `.cyclone-btn` elements and displays
        Bootstrap toasts. The legacy inline handler below duplicated


### PR DESCRIPTION
## Summary
- remove inline theme toggle script from `sonic_dashboard.html`
- load the shared `sonic_theme_toggle.js` script instead

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'solana')*