### PR TITLE
Update hedge report tables

### DIFF
--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -66,6 +66,18 @@ th.sorted-desc .sort-indicator { color: var(--primary); }
   font-style: italic;
 }
 
+/* Container for both tables so they sit flush */
+.dual-table-wrapper {
+  display: flex;
+  width: 100%;
+  gap: 0;
+}
+
+.dual-table-wrapper .positions-table-wrapper {
+  flex: 1 1 0;
+  width: auto;
+}
+
 /* Outer borders for tables */
 #short-table {
   border-left: var(--panel-border-width) solid var(--panel-border);

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -23,7 +23,8 @@
 
 <div class="sonic-section-container sonic-section-middle mt-3">
   <div class="sonic-content-panel">
-    <div class="positions-table-wrapper">
+    <div class="dual-table-wrapper">
+      <div class="positions-table-wrapper">
         <h3 class="section-title icon-inline text-center mb-2"><span>📉</span><span>SHORT</span></h3>
         <table id="short-table" class="positions-table">
           <thead>
@@ -93,9 +94,7 @@
           </tfoot>
         </table>
       </div>
-    </div>
-  <div class="sonic-content-panel">
-    <div class="positions-table-wrapper">
+      <div class="positions-table-wrapper">
         <h3 class="section-title icon-inline text-center mb-2"><span>📈</span><span>LONG</span></h3>
         <table id="long-table" class="positions-table">
           <thead>


### PR DESCRIPTION
## Summary
- show long and short tables in one container on the hedge report
- add flex wrapper in CSS to keep them flush

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'solana')*