### PR TITLE
Fix hedge report container width

### DIFF
--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -78,6 +78,12 @@ th.sorted-desc .sort-indicator { color: var(--primary); }
   width: auto;
 }
 
+/* Expand the main panel to use the full section width */
+.hedge-report-panel {
+  max-width: none;
+  width: 100%;
+}
+
 /* Outer borders for tables */
 #short-table {
   border-left: var(--panel-border-width) solid var(--panel-border);

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -22,7 +22,7 @@
 <!-- Page Title Removed -->
 
 <div class="sonic-section-container sonic-section-middle mt-3">
-  <div class="sonic-content-panel">
+  <div class="sonic-content-panel hedge-report-panel">
     <div class="dual-table-wrapper">
       <div class="positions-table-wrapper">
         <h3 class="section-title icon-inline text-center mb-2"><span>📉</span><span>SHORT</span></h3>


### PR DESCRIPTION
## Summary
- expand the hedge report's top container to use full width
- add CSS class for wider panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'solana')*