### PR TITLE
Add DB recovery option in LaunchPad

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ ALTER TABLE positions ADD COLUMN status TEXT DEFAULT 'ACTIVE';
 for required configuration files and creates the `logs/` and `data/` directories
 if needed. Invoke this at application launch to verify the environment is ready.
 
+## Database Recovery
+
+If the SQLite file becomes corrupted, you can rebuild it directly from the
+Launch Pad utility:
+
+```bash
+python launch_pad.py
+```
+
+Open the **Operations** menu and choose **Recover Database**. This deletes the
+damaged `mother_brain.db` and recreates it with the required tables.
+
 ## Windows Branch Name Compatibility
 If a remote branch name contains characters that are invalid on Windows (such as `>` or `:`), Git cannot create the local reference. Rename the branch on a Unix-like system or ask the author to rename it. For example:
 

--- a/launch_pad.py
+++ b/launch_pad.py
@@ -13,6 +13,8 @@ from core.core_imports import configure_console_log
 from core.logging import log
 from monitor.operations_monitor import OperationsMonitor
 from test_core import TestCore
+from data.data_locker import DataLocker
+from core.constants import DB_PATH
 
 console = Console()
 configure_console_log()
@@ -66,6 +68,7 @@ def operations_menu():
         console.print("[bold cyan]Operations[/bold cyan]")
         console.print("1) Run POST")
         console.print("2) 🛠️ Core Config Test")
+        console.print("3) Recover Database")
         console.print("b) Back")
         choice = input("→ ").strip().lower()
         if choice == "1":
@@ -79,6 +82,17 @@ def operations_menu():
 
             result = monitor.run_configuration_test()
             log.info("Config Test Result", payload=result)
+            input("Press ENTER to continue...")
+        elif choice == "3":
+            console.print("[yellow]Attempting database recovery...[/yellow]")
+            dl = DataLocker(str(DB_PATH))
+            dl.db.recover_database()
+            dl.initialize_database()
+            dl._seed_modifiers_if_empty()
+            dl._seed_wallets_if_empty()
+            dl._seed_thresholds_if_empty()
+            dl.close()
+            console.print("[green]Database recovery complete.[/green]")
             input("Press ENTER to continue...")
         elif choice == "b":
             break

--- a/tests/test_launch_pad_recover.py
+++ b/tests/test_launch_pad_recover.py
@@ -1,0 +1,57 @@
+import builtins
+import sys
+import types
+
+dummy_rich = types.ModuleType("rich")
+dummy_console = types.ModuleType("rich.console")
+dummy_text = types.ModuleType("rich.text")
+
+class _Console:
+    def print(self, *args, **kwargs):
+        pass
+
+dummy_console.Console = _Console
+dummy_text.Text = str
+dummy_rich.console = dummy_console
+dummy_rich.text = dummy_text
+sys.modules.setdefault("rich", dummy_rich)
+sys.modules.setdefault("rich.console", dummy_console)
+sys.modules.setdefault("rich.text", dummy_text)
+
+import launch_pad
+
+
+def test_operations_menu_recover(monkeypatch):
+    called = {"recover": False}
+
+    class DummyDB:
+        def recover_database(self):
+            called["recover"] = True
+
+    class DummyLocker:
+        def __init__(self, path):
+            self.db = DummyDB()
+
+        def initialize_database(self):
+            pass
+
+        def _seed_modifiers_if_empty(self):
+            pass
+
+        def _seed_wallets_if_empty(self):
+            pass
+
+        def _seed_thresholds_if_empty(self):
+            pass
+
+        def close(self):
+            pass
+
+    inputs = iter(["3", "", "b"])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+    monkeypatch.setattr(launch_pad, "clear_screen", lambda: None)
+    monkeypatch.setattr(launch_pad, "DataLocker", DummyLocker)
+
+    launch_pad.operations_menu()
+
+    assert called["recover"] is True


### PR DESCRIPTION
## Summary
- allow LaunchPad to recover the database
- document the new recovery option
- test that selecting recover in Operations menu calls `recover_database`

## Testing
- `pytest tests/test_launch_pad_recover.py -q`
- `pytest tests/test_database_recovery.py::test_recover_malformed_db -q`
