### PR TITLE
Add config update check in OperationsMonitor

### DIFF
--- a/cyclone/cyclone_engine.py
+++ b/cyclone/cyclone_engine.py
@@ -277,6 +277,13 @@ class Cyclone:
         log.info("Starting Operations Monitor via MonitorCore", source="Cyclone")
         await asyncio.to_thread(self.monitor_core.run_by_name, "operations_monitor")
 
+        # Refresh alert limits configuration from the database each cycle. The
+        # OperationsMonitor will update the DB entry when the source file
+        # changes. Reloading here keeps ``self.config`` in sync for AlertCore.
+        new_config = self.data_locker.system.get_var("alert_limits") or {}
+        if new_config:
+            self.config = new_config
+
     async def enrich_positions(self):
         log.info("🚀 Enriching All Positions via PositionCore...", "Cyclone")
         await self.position_core.enrich_positions()

--- a/tests/test_operations_monitor.py
+++ b/tests/test_operations_monitor.py
@@ -7,9 +7,21 @@ import monitor.operations_monitor as om
 from utils.schema_validation_service import SchemaValidationService
 
 
+class DummySystem:
+    def __init__(self):
+        self.store = {}
+
+    def get_var(self, key):
+        return self.store.get(key)
+
+    def set_var(self, key, value):
+        self.store[key] = value
+
+
 class DummyLocker:
     def __init__(self, *a, **k):
         self.ledger = types.SimpleNamespace(insert_ledger_entry=lambda *a, **k: None)
+        self.system = DummySystem()
 
 
 @pytest.fixture(autouse=True)
@@ -53,3 +65,18 @@ def test_run_configuration_test_valid_file(tmp_path, monkeypatch):
     monitor = om.OperationsMonitor()
     result = monitor.run_configuration_test()
     assert result["config_success"] is True
+
+
+def test_check_for_config_updates(tmp_path, monkeypatch):
+    cfg = tmp_path / "alert_limits.json"
+    data = {"a": 1}
+    with open(cfg, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    monkeypatch.setattr(om, "ALERT_LIMITS_PATH", cfg)
+
+    monitor = om.OperationsMonitor()
+    updated = monitor.check_for_config_updates()
+
+    assert updated is True
+    assert monitor.data_locker.system.get_var("alert_limits") == data


### PR DESCRIPTION
## Summary
- implement `check_for_config_updates` in OperationsMonitor
- refresh Cyclone engine config after each operations cycle
- document OperationsMonitor
- extend tests for the new behaviour

## Testing
- `pytest tests/test_operations_monitor.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: solana, flask, etc.)*