### PR TITLE
Add Startup Service option to Launch Pad

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ ALTER TABLE positions ADD COLUMN status TEXT DEFAULT 'ACTIVE';
 `StartUpService.run_all()` ensures the `mother_brain.db` database exists, checks
 for required configuration files and creates the `logs/` and `data/` directories
 if needed. Invoke this at application launch to verify the environment is ready.
+The Launch Pad console exposes this check via a **Startup Service** option in its main menu.
 
 ## Database Recovery
 

--- a/launch_pad.py
+++ b/launch_pad.py
@@ -15,6 +15,7 @@ from monitor.operations_monitor import OperationsMonitor
 from test_core import TestCore
 from data.data_locker import DataLocker
 from core.constants import DB_PATH
+from utils.startup_service import StartUpService
 
 console = Console()
 configure_console_log()
@@ -125,9 +126,10 @@ def main_menu():
         console.print("1) 🦔 Sonic App + 🖥️ Sonic Monitor")
         console.print("2) 🌀 Launch Cyclone")
         console.print("3) Launch Sonic Web")
-        console.print("4) ⚙️ Operations")
-        console.print("5) 🧪 Test Core")
-        console.print("6) Exit")
+        console.print("4) 🌅 Startup Service")
+        console.print("5) ⚙️ Operations")
+        console.print("6) 🧪 Test Core")
+        console.print("7) Exit")
         choice = input("→ ").strip()
         if choice == "1":
             launch_web_and_monitor()
@@ -136,10 +138,13 @@ def main_menu():
         elif choice == "3":
             launch_sonic_web()
         elif choice == "4":
-            operations_menu()
+            StartUpService.run_all()
+            input("Press ENTER to continue...")
         elif choice == "5":
-            test_core_menu()
+            operations_menu()
         elif choice == "6":
+            test_core_menu()
+        elif choice == "7":
             console.print("Goodbye!", style="green")
             break
         else:


### PR DESCRIPTION
## Summary
- add Startup Service option in Launch Pad main menu
- document new menu option in README

## Testing
- `pytest -q` *(fails: 22 errors during collection)*