### PR TITLE
Improve startup checks

### DIFF
--- a/utils/startup_service.py
+++ b/utils/startup_service.py
@@ -3,8 +3,20 @@ from core.constants import (
     CONFIG_PATH,
     ALERT_LIMITS_PATH,
     BASE_DIR,
+    SONIC_SAUCE_PATH,
+    COM_CONFIG_PATH,
+    THEME_CONFIG_PATH,
+    CONFIG_DIR,
+    MONITOR_DIR,
+    IMAGE_DIR,
+    DATA_DIR,
+    LOG_DIR,
 )
-# from utils.path_audit import maybe_create_mother_brain
+from utils.schema_validation_service import SchemaValidationService
+from data.data_locker import DataLocker
+from monitor.operations_monitor import OperationsMonitor
+from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+from utils.path_audit import run_audit
 import os
 from pathlib import Path
 import sqlite3
@@ -29,7 +41,12 @@ class StartUpService:
         StartUpService.check_for_mother_brain()
         StartUpService.verify_required_paths()
         StartUpService.ensure_alert_limits()
+        StartUpService.check_env_vars()
+        StartUpService.initialize_database()
         StartUpService.ensure_required_directories()
+        StartUpService.run_path_audit()
+        StartUpService.run_operations_tests()
+        StartUpService.run_twilio_heartbeat()
         log.success("✅ All startup checks passed.\n", source="StartUpService")
 
     @staticmethod
@@ -39,7 +56,15 @@ class StartUpService:
     @staticmethod
     def verify_required_paths():
         missing = []
-        for path in [DB_PATH, CONFIG_PATH, ALERT_LIMITS_PATH]:
+        required = [
+            DB_PATH,
+            CONFIG_PATH,
+            ALERT_LIMITS_PATH,
+            SONIC_SAUCE_PATH,
+            COM_CONFIG_PATH,
+            THEME_CONFIG_PATH,
+        ]
+        for path in required:
             if not os.path.exists(path):
                 missing.append(path)
 
@@ -67,13 +92,91 @@ class StartUpService:
             log.success("✅ Default alert_limitsz.json created.", source="StartUpService")
         else:
             log.info("✅ alert_limitsz.json found.", source="StartUpService")
+            valid = SchemaValidationService.validate_schema(
+                str(ALERT_LIMITS_PATH),
+                SchemaValidationService.ALERT_LIMITS_SCHEMA,
+                name="Alert Ranges",
+            )
+            if not valid:
+                raise SystemExit(
+                    "Startup check failed: alert_limits.json schema invalid"
+                )
 
     @staticmethod
     def ensure_required_directories():
-        required_dirs = [os.path.join(BASE_DIR, "logs"), os.path.join(BASE_DIR, "data")]
+        required_dirs = [
+            LOG_DIR,
+            DATA_DIR,
+            CONFIG_DIR,
+            MONITOR_DIR,
+            IMAGE_DIR,
+        ]
         for d in required_dirs:
             Path(d).mkdir(parents=True, exist_ok=True)
             log.info(f"📁 Ensured directory exists: {d}", source="StartUpService")
+
+    @staticmethod
+    def check_env_vars():
+        required = [
+            "SMTP_SERVER",
+            "SMTP_PORT",
+            "SMTP_USERNAME",
+            "SMTP_PASSWORD",
+            "SMTP_DEFAULT_RECIPIENT",
+            "TWILIO_ACCOUNT_SID",
+            "TWILIO_AUTH_TOKEN",
+            "TWILIO_FROM_PHONE",
+            "TWILIO_TO_PHONE",
+        ]
+        missing = [var for var in required if not os.getenv(var)]
+        if missing:
+            log.critical("❌ Missing required environment variables:")
+            for var in missing:
+                log.error(f"  - {var}", source="StartUpService")
+            raise SystemExit("Startup failed due to missing environment variables.")
+        log.info("✅ Required environment variables present.", source="StartUpService")
+
+    @staticmethod
+    def initialize_database():
+        try:
+            dl = DataLocker(str(DB_PATH))
+            dl.close()
+            log.info(
+                "✅ Database initialized and connectivity verified.",
+                source="StartUpService",
+            )
+        except Exception as exc:
+            log.critical(f"❌ Database initialization failed: {exc}", source="StartUpService")
+            raise SystemExit("Startup failed during database initialization.")
+
+    @staticmethod
+    def run_operations_tests():
+        try:
+            monitor = OperationsMonitor()
+            monitor.run_startup_post()
+        except Exception as exc:
+            log.error(f"Operations POST tests failed: {exc}", source="StartUpService")
+
+    @staticmethod
+    def run_twilio_heartbeat():
+        try:
+            result = CheckTwilioHeartbeartService({}).check(dry_run=True)
+            if not result.get("success"):
+                log.error(
+                    f"Twilio heartbeat check failed: {result.get('error')}",
+                    source="StartUpService",
+                )
+            else:
+                log.info("✅ Twilio credentials verified.", source="StartUpService")
+        except Exception as exc:
+            log.error(f"Twilio heartbeat error: {exc}", source="StartUpService")
+
+    @staticmethod
+    def run_path_audit():
+        try:
+            run_audit()
+        except Exception as exc:
+            log.error(f"Path audit failed: {exc}", source="StartUpService")
 
 # --- Allow Standalone Run ---
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- broaden verified config paths
- validate alert limits schema
- enforce environment variable presence
- initialize database at boot
- ensure additional directories
- run safety checks for paths, POST tests and Twilio heartbeat

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'solana')*