### PR TITLE
Add Twilio console link

### DIFF
--- a/templates/system/xcom_config.html
+++ b/templates/system/xcom_config.html
@@ -52,6 +52,10 @@
                   <input type="text" name="twilio[default_to_phone]" value="{{ twilio.default_to_phone or '' }}" class="form-control">
                 </div>
 
+                <div class="col-md-12">
+                  <a href="https://console.twilio.com/" target="_blank" class="text-decoration-none">Open Twilio Console</a>
+                </div>
+
                 <!-- 🔍 DISPLAY VALUES -->
                 <div class="col-md-12 mt-2">
                   <label class="form-label text-muted">🔍 Loaded Twilio Config (read-only)</label>


### PR DESCRIPTION
## Summary
- link to the Twilio console from the Twilio settings panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*