### PR TITLE
Update alert limit config filename

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -59,7 +59,7 @@ def update_config(new_config: dict, filename: str | None = None) -> dict:
     if filename:
         filename = (
             str(ALERT_LIMITS_PATH)
-            if Path(filename).name in {"alert_limits.json", "alert_limitsz.json"}
+            if Path(filename).name == "alert_limits.json"
             else os.path.abspath(filename)
         )
 

--- a/tests/live_price_ticker_simulation.py
+++ b/tests/live_price_ticker_simulation.py
@@ -93,7 +93,7 @@ async def live_price_ticker_simulation():
 
     repo = AlertRepository(data_locker)
     enrichment = AlertEnrichmentService(data_locker)
-    config_loader = lambda: load_config("alert_limitsz.json") or {}
+    config_loader = lambda: load_config("alert_limits.json") or {}
     notification_service = NotificationService(config_loader)
 
     service = AlertService(repo, enrichment, config_loader)

--- a/tests/system/system_test_helpers.py
+++ b/tests/system/system_test_helpers.py
@@ -4,9 +4,9 @@ import os
 from core.core_imports import retry_on_locked
 
 @retry_on_locked()
-def create_temp_alert_limits_json(filepath="alert_limitsz.json"):
+def create_temp_alert_limits_json(filepath="alert_limits.json"):
     """
-    Create a dummy alert_limitsz.json if it doesn't exist.
+    Create a dummy alert_limits.json if it doesn't exist.
     """
     if os.path.exists(filepath):
         return  # ✅ Already exists, do nothing

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -9,7 +9,7 @@ from core.core_imports import log
 def save_config(filename: str, data: dict) -> None:
     """Save ``data`` to ``filename`` resolving default locations."""
     path = Path(filename)
-    if path.name in {"alert_limits.json", "alert_limitsz.json"}:
+    if path.name == "alert_limits.json":
         path = ALERT_LIMITS_PATH
     elif not path.is_absolute():
         path = CONFIG_DIR / path

--- a/utils/json_manager.py
+++ b/utils/json_manager.py
@@ -15,7 +15,7 @@ from core.core_imports import ALERT_LIMITS_PATH
 from core.constants import THEME_CONFIG_PATH, SONIC_SAUCE_PATH
 
 class JsonType(Enum):
-    ALERT_LIMITS = "alert_limitsz.json"
+    ALERT_LIMITS = "alert_limits.json"
     THEME_CONFIG = "theme_config.json"
     SONIC_SAUCE = "sonic_sauce.json"
     SONIC_CONFIG = "sonic_config.json"

--- a/utils/startup_service.py
+++ b/utils/startup_service.py
@@ -131,7 +131,7 @@ class StartUpService:
     @staticmethod
     def ensure_alert_limits():
         if not os.path.exists(ALERT_LIMITS_PATH):
-            log.warning("⚠️ alert_limitsz.json not found. Creating default template...")
+            log.warning("⚠️ alert_limits.json not found. Creating default template...")
             default = {
                 "alert_ranges": {},
                 "global_alert_config": {
@@ -140,10 +140,10 @@ class StartUpService:
                     "thresholds": {}
                 }
             }
-            save_config("alert_limitsz.json", default)
-            log.success("✅ Default alert_limitsz.json created.", source="StartUpService")
+            save_config("alert_limits.json", default)
+            log.success("✅ Default alert_limits.json created.", source="StartUpService")
         else:
-            log.info("✅ alert_limitsz.json found.", source="StartUpService")
+            log.info("✅ alert_limits.json found.", source="StartUpService")
             valid = SchemaValidationService.validate_schema(
                 str(ALERT_LIMITS_PATH),
                 SchemaValidationService.ALERT_LIMITS_SCHEMA,


### PR DESCRIPTION
## Summary
- reference `alert_limits.json` consistently
- generate default alert limits config with the new filename
- update helper and simulation tests to use the new path

## Testing
- `pytest tests/test_operations_monitor.py -q`