### PR TITLE
Remove duplicate DB_PATH env override

### DIFF
--- a/core/core_imports.py
+++ b/core/core_imports.py
@@ -3,13 +3,6 @@
 Centralized import hub for high-usage components in the Sonic Dashboard.
 Use this instead of importing from `core/__init__.py`.
 """
-import os
-
-# Absolute path to /data/mother_brain.db with env override
-DB_PATH = os.getenv(
-    "DB_PATH",
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data", "mother_brain.db"))
-)
 
 from core.logging import log, configure_console_log
 #from core.locker_factory import get_locker


### PR DESCRIPTION
## Summary
- remove redundant DB_PATH definition from `core_imports`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*