### PR TITLE
Adjust hedge report table widths

### DIFF
--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -78,6 +78,15 @@ th.sorted-desc .sort-indicator { color: var(--primary); }
   width: auto;
 }
 
+/* Make the first table wider to prevent crowding */
+.dual-table-wrapper .positions-table-wrapper:first-child {
+  flex-basis: 60%;
+}
+
+.dual-table-wrapper .positions-table-wrapper:last-child {
+  flex-basis: 40%;
+}
+
 /* Expand the main panel to use the full section width */
 .hedge-report-panel {
   max-width: none;


### PR DESCRIPTION
## Summary
- widen the short table on the Hedge Report page so it can fit more data

## Testing
- `pytest -q`