### PR TITLE
Load env file in startup service

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,13 @@ ALTER TABLE positions ADD COLUMN status TEXT DEFAULT 'ACTIVE';
 `utils.startup_service` provides a unified `StartUpService` helper. Running
 `StartUpService.run_all()` ensures the `mother_brain.db` database exists, checks
 for required configuration files and creates the `logs/` and `data/` directories
-if needed. Progress is shown via a simple dot spinner between steps. When all
-checks pass a short startup sound (`static/sounds/web_station_startup.mp3`) will
-play. On failure the "death spiral" tone is used instead. Invoke this at
-application launch to verify the environment is ready. The Launch Pad console
-exposes this check via a **Startup Service** option in its main menu.
+if needed. Progress is shown via a simple dot spinner between steps. Environment
+variables are automatically loaded from a `.env` file in the project root (with
+`.env.example` as a fallback) before any checks run. When all checks pass a
+short startup sound (`static/sounds/web_station_startup.mp3`) will play. On
+failure the "death spiral" tone is used instead. Invoke this at application
+launch to verify the environment is ready. The Launch Pad console exposes this
+check via a **Startup Service** option in its main menu.
 
 ## Database Recovery
 

--- a/utils/startup_service.py
+++ b/utils/startup_service.py
@@ -1,3 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(Path(__file__).resolve().parent.parent))
+
 from core.constants import (
     DB_PATH,
     CONFIG_PATH,
@@ -18,12 +24,19 @@ from monitor.operations_monitor import OperationsMonitor
 from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
 from utils.path_audit import run_audit
 from xcom.sound_service import SoundService
-import os
-from pathlib import Path
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv(*_a, **_k):
+        return False
 import sqlite3
-import sys
 import time
 import threading
+
+# Automatically load environment variables
+dotenv_file = BASE_DIR / ".env"
+if not load_dotenv(dotenv_file):
+    load_dotenv(BASE_DIR / ".env.example")
 
 
 class DotSpinner:


### PR DESCRIPTION
## Summary
- load `.env` automatically in `utils/startup_service`
- document that the startup checks load environment variables from `.env`

## Testing
- `pytest -q`
